### PR TITLE
adding orders value to ab metrics

### DIFF
--- a/node/abTest/analysis/time/initialStage.ts
+++ b/node/abTest/analysis/time/initialStage.ts
@@ -23,7 +23,7 @@ export const InitialParameters = (proportion: number, workspaces: ABTestWorkspac
     for (const workspace of workspaces) {
         [noOrderSessions, orderSessions] = workspace.name !== MasterWorkspaceName ? [0, 0]
             : [(1 - proportion) * INFINITE_MASS, proportion * INFINITE_MASS]
-        map.set(workspace.name, WorkspaceData(workspace.name, noOrderSessions + orderSessions, orderSessions))
+        map.set(workspace.name, WorkspaceData(workspace.name, noOrderSessions + orderSessions, orderSessions, 0))
     }
     return map
 }

--- a/node/clients/storedash.ts
+++ b/node/clients/storedash.ts
@@ -22,18 +22,19 @@ export default class Storedash extends ExternalClient {
         const workspacesData: WorkspaceData[] = []
         for (const metric of metrics) {
             const m: StoreDashResponse = metric as unknown as StoreDashResponse
-            workspacesData.push(WorkspaceData(m.workspace, m['data.sessions'], m['data.sessionsOrdered']))
+            workspacesData.push(WorkspaceData(m.workspace, m['data.sessions'], m['data.sessionsOrdered'], m['data.ordersValue']))
         }
         return workspacesData
     }
 }
 
 const AggregationQuery = (from: string): string => (
-    '?from=' + from + '&to=now&operation=sum&fields=data.sessions,data.sessionsOrdered&aggregateBy=workspace'
+    '?from=' + from + '&to=now&operation=sum&fields=data.sessions,data.sessionsOrdered,data.ordersValue&aggregateBy=workspace'
 )
 
 interface StoreDashResponse {
     workspace: string
     'data.sessions': number
     'data.sessionsOrdered': number
+    'data.ordersValue': number
 }

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -18,6 +18,7 @@ declare global {
     OrderSessions: number
     NoOrderSessions: number
     Conversion: number
+    OrdersValue: number
   }
 
   export interface WorkspaceCompleteData {
@@ -42,6 +43,8 @@ declare global {
     ConversionBLast24Hours: number
     ProbabilityAlternativeBeatMaster: number
     PValue: number
+    WorkspaceAOrdersValue: number
+     WorkspaceBOrdersValue: number
   }
 
   export interface ABTestParameters {

--- a/node/utils/evaluation-response.ts
+++ b/node/utils/evaluation-response.ts
@@ -15,6 +15,8 @@ export const DefaultEvaluationResponse = (abTestBeginning: string, workspaceANam
     WorkspaceB: workspaceBName,
     WorkspaceBSessions: 0,
     WorkspaceBSessionsLast24Hours: 0,
+    WorkspaceAOrdersValue: 0,
+    WorkspaceBOrdersValue: 0,
 })
 
 export const EvaluationResponse = (abTestBeginning: string, workspaceAData: WorkspaceCompleteData, workspaceBData: WorkspaceCompleteData, winner: string, lossA: number, lossB: number, probabilityOneBeatTwo: number, pValue: number): TestResult => ({
@@ -34,4 +36,6 @@ export const EvaluationResponse = (abTestBeginning: string, workspaceAData: Work
     WorkspaceB: workspaceBData.SinceBeginning.Workspace,
     WorkspaceBSessions: workspaceBData.SinceBeginning.Sessions,
     WorkspaceBSessionsLast24Hours: workspaceBData.Last24Hours.Sessions,
+    WorkspaceAOrdersValue: workspaceAData.SinceBeginning.OrdersValue,
+    WorkspaceBOrdersValue: workspaceBData.SinceBeginning.OrdersValue,
 })

--- a/node/utils/workspace.ts
+++ b/node/utils/workspace.ts
@@ -8,12 +8,13 @@ export const WorkspaceToBetaDistribution = (Workspace: WorkspaceData): ABTestPar
     b: Workspace.NoOrderSessions + 1,
 })
 
-export const WorkspaceData = (Workspace: string, TotalSessions: number, OrderSessions: number): WorkspaceData => ({
+export const WorkspaceData = (Workspace: string, TotalSessions: number, OrderSessions: number, OrdersValue: number): WorkspaceData => ({
     Conversion: (TotalSessions > 0 ? OrderSessions / TotalSessions : 0),
     NoOrderSessions: (TotalSessions - OrderSessions),
     OrderSessions: (OrderSessions),
     Sessions: TotalSessions,
     Workspace: `${Workspace}`,
+    OrdersValue: (OrdersValue),
 })
 
 const ErrorWorkspaceData = (workspace: string): WorkspaceData => ({
@@ -22,6 +23,7 @@ const ErrorWorkspaceData = (workspace: string): WorkspaceData => ({
     OrderSessions: 0,
     Sessions: 0,
     Workspace: workspace,
+    OrdersValue: 0,
 })
 
 export const FilteredWorkspacesData = (workspacesData: WorkspaceData[], testingWorkspaces: string[]): WorkspaceData[] => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add "orders value" (revenue) to ab tests metrics

#### What problem is this solving?
Adding another metric for clients to use when analysing ab tests (adding it to the tool belt in the near future) and later to be used as the main metric if the client wishes to do so. 

#### How should this be manually tested?
Running the ab tester linked to some ab test and checking the stats.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.