### PR TITLE
Stop getting test metadata every time pulse is listened

### DIFF
--- a/node/abTest/commands/status.ts
+++ b/node/abTest/commands/status.ts
@@ -5,8 +5,8 @@ export async function ABTestStatus(ctx: Context): Promise<TestResult[]> {
   try {
     const workspaces = await abTestRouter.getWorkspaces(account)
     if (workspaces === null) {
-      ctx.response.status = 400
-      throw new Error('Test not initialized')
+      ctx.response.status = 200
+      return []
     }
 
     const testData = await storage.getTestData(ctx)

--- a/node/abTest/commands/update.ts
+++ b/node/abTest/commands/update.ts
@@ -7,8 +7,8 @@ export async function UpdateStatusOnEvent(ctx: Context): Promise<void> {
   try {
     const workspacesMetadata = await abTestRouter.getWorkspaces(account)
     const testingWorkspaces = new TestingWorkspaces(workspacesMetadata)
-    const testData = await storage.getTestData(ctx)
     if (testingWorkspaces.Length() > 0) {
+      const testData = await storage.getTestData(ctx)
       let beginning = testData.dateOfBeginning
       let hours = testData.initialStageTime
       let proportion = testData.initialProportion

--- a/node/abTest/commands/update.ts
+++ b/node/abTest/commands/update.ts
@@ -1,6 +1,6 @@
+import { TestType } from '../../clients/vbase'
 import TestingWorkspaces from '../../typings/testingWorkspace'
 import { UpdateParameters } from '../updateParameters'
-import { TestType } from '../../clients/vbase';
 
 export async function UpdateStatusOnEvent(ctx: Context): Promise<void> {
   const { vtex: { account }, clients: { abTestRouter, logger, storedash, storage } } = ctx


### PR DESCRIPTION
#### What is the purpose of this pull request?
As a quick fix, this verifies if there is a test being run before calling VBase for test metadata. In a following PR I'll address this problem more carefully by don't returning an error when couldn't be found test metadata and treating properly this case.

#### What problem is this solving?
We were trying to get test metadata every time the event was listened and when there is no test metadata, AB-Tester returned an error.

#### How should this be manually tested?
With this version linked, test send pulse event to ab-tester and verifies if it stopped to return an error.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
