### PR TITLE
Add option of selecting test type

### DIFF
--- a/node/abTest/commands/initialize.ts
+++ b/node/abTest/commands/initialize.ts
@@ -28,8 +28,9 @@ export function InitializeAbTestForWorkspaceWithParameters(ctx: Context): Promis
 }
 
 export async function InitializeAbTestWithBodyParameters(ctx: Context): Promise<void> {
-    const { InitializingWorkspace, Hours, Proportion } = await getRequestParams(ctx)
-    const [ workspaceName, hoursOfInitialStage, proportionOfTraffic ] = [ InitializingWorkspace, Hours, Proportion ].map(firstOrDefault)
+    const { InitializingWorkspace, Hours, Proportion, Type } = await getRequestParams(ctx)
+    const [ workspaceName, hoursOfInitialStage, proportionOfTraffic, type ] = [ InitializingWorkspace, Hours, Proportion, Type ].map(firstOrDefault)
+    const testType = TestType[type as keyof typeof TestType]
 
     if (Number.isNaN(Number(hoursOfInitialStage)))
     {
@@ -40,7 +41,7 @@ export async function InitializeAbTestWithBodyParameters(ctx: Context): Promise<
         throw new Error(`An error occurred when reading proportion of traffic being distributed between workspaces: value is not a number.`)
     }
 
-    return InitializeAbTest(workspaceName, Number(hoursOfInitialStage), Number(proportionOfTraffic), ctx)
+    return InitializeAbTest(workspaceName, Number(hoursOfInitialStage), Number(proportionOfTraffic), ctx, testType)
 }
 
 async function InitializeAbTest(workspaceName: string, hoursOfInitialStage: number, proportionOfTraffic: number, ctx: Context, testType: TestType = TestType.conversion): Promise<void> {

--- a/node/abTest/commands/initialize.ts
+++ b/node/abTest/commands/initialize.ts
@@ -65,7 +65,7 @@ async function InitializeAbTest(workspaceName: string, hoursOfInitialStage: numb
             parameterPerWorkspace: tsmap,
         })
 
-        await storage.initializeABtest(hoursOfInitialStage, proportionOfTraffic, ctx)
+        await storage.initializeABtest(hoursOfInitialStage, proportionOfTraffic, testType, ctx)
         logger.info({message: `A/B Test initialized in ${account} for workspace ${workspaceName}`, account: `${account}`, workspace: `${workspaceName}`, proportion: `${proportionOfTraffic}`, method: 'TestInitialized' })
     } catch (err) {
         if (err.status === 404) {

--- a/node/abTest/commands/initialize.ts
+++ b/node/abTest/commands/initialize.ts
@@ -66,7 +66,7 @@ async function InitializeAbTest(workspaceName: string, hoursOfInitialStage: numb
         })
 
         await storage.initializeABtest(hoursOfInitialStage, proportionOfTraffic, testType, ctx)
-        logger.info({message: `A/B Test initialized in ${account} for workspace ${workspaceName}`, account: `${account}`, workspace: `${workspaceName}`, proportion: `${proportionOfTraffic}`, method: 'TestInitialized' })
+        logger.info({message: `A/B Test initialized in ${account} for workspace ${workspaceName}`, account: `${account}`, workspace: `${workspaceName}`, proportion: `${proportionOfTraffic}`, type: `${testType}`, method: 'TestInitialized' })
     } catch (err) {
         if (err.status === 404) {
             err.message = 'Workspace not found'

--- a/node/clients/vbase.ts
+++ b/node/clients/vbase.ts
@@ -51,7 +51,7 @@ export default class VBase extends BaseClient {
     }
   }
 
-  public initializeABtest = async (initialTime: number, proportion: number, ctx: Context) => {
+  public initializeABtest = async (initialTime: number, proportion: number, testType: TestType, ctx: Context) => {
     const beginning = new Date().toISOString().substr(0, 16)
     try {
       const initialCache = InitialWorkspaceDataCache(new Date())
@@ -65,7 +65,7 @@ export default class VBase extends BaseClient {
         dateOfBeginning: beginning,
         initialProportion: proportion,
         initialStageTime: initialTime,
-        testType: TestType.conversion,
+        testType: testType,
       } as VBaseABTestData, testFileName, ctx)
     } catch (ex) {
       ctx.vtex.logger.error(ex)

--- a/node/package.json
+++ b/node/package.json
@@ -13,7 +13,7 @@
     "@vtex/api": "^3.66.2",
     "tslint": "^5.20.1",
     "tslint-config-vtex": "^2.0.0",
-    "typescript": "3.7.3",
+    "typescript": "3.8.3",
     "typescript-map": "^0.0.7"
   },
   "scripts": {

--- a/node/utils/BodyParser/getRequestParams.ts
+++ b/node/utils/BodyParser/getRequestParams.ts
@@ -2,11 +2,13 @@ import readBody from './readRequestBody'
 
 const expectedFields = ['InitializingWorkspace', 'Hours', 'Proportion']
 
-export default async (ctx: Context) => {
+export default async (ctx: Context) => {   
     const bodyContent = await readBody(ctx)
     checkForExpectedFields(bodyContent)
-    const { InitializingWorkspace, Hours, Proportion } = bodyContent
-    return { InitializingWorkspace, Hours, Proportion }
+    const { InitializingWorkspace, Hours, Proportion, Type } = bodyContent  
+    checkTestType(Type)
+
+    return { InitializingWorkspace, Hours, Proportion, Type }
 }
 
 const checkForExpectedFields = (object: object) => {
@@ -15,5 +17,11 @@ const checkForExpectedFields = (object: object) => {
         if (!(field in object)) {
             throw new Error(`Error getting request's parameters: make sure to set the ${field} field`)
         }
+    }
+}
+
+const checkTestType = (Type: string) => {
+    if (Type && Type !== 'conversion' && Type !== 'revenue') {
+        throw new Error(`Error setting test type: please make sure to spell it correctly (either 'conversion' or 'revenue')`)
     }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1844,10 +1844,10 @@ typescript-map@^0.0.7:
   resolved "https://registry.yarnpkg.com/typescript-map/-/typescript-map-0.0.7.tgz#69d1937af203d1c9a32fc20ee3d8813e8f1a745f"
   integrity sha512-qLGAeshAnryHN1ycLS4nk+7195MYXbrCzI62bXl8TEqigD5otgHUGIdWsdn5MsbAX3ba5ZtkKEAM0LgaVUAdnQ==
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make it possible for the user to select the type of A/B test (either `conversion` or `revenue`) to be initialized.

If no type is selected, the test starts as a `conversion` test (the already existing users select no type on their requests and expect the test to be initialized as of type `conversion`). 

If the type is misspelled, an error is thrown. 

#### How should this be manually tested?
One should call the app, try to
1. start a test without specifying its type;
1. start a test specifying a (correctly spelled) type;
1. start a test setting a misspelled type

and verify whether the  event goes as expected.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
