### PR TITLE
Improve error handling / finish

### DIFF
--- a/node/abTest/commands/finish.ts
+++ b/node/abTest/commands/finish.ts
@@ -8,52 +8,39 @@ import EndTest from '../endTest'
 export async function FinishAbTestForWorkspace(ctx: Context): Promise<void> {
   const { vtex: { account, route: { params: { finishingWorkspace } } }, clients: { abTestRouter, storage } } = ctx
   const workspaceName = firstOrDefault(finishingWorkspace)
-  let testingWorkspaces: TestingWorkspaces
-  try {
-    testingWorkspaces = await abTestRouter.getWorkspaces(account)
-  } catch (err) {
-    err.message = 'Error getting test metadata from router API'
-    ctx.vtex.logger.error({ status: ctx.status, message: err.message })
-    throw err
-  }
-  if (testingWorkspaces.Length() === 0) {
-    ctx.response.status = 404
-    throw new NotFoundError(`Test not initialized for this account`)
-  }
-
-  if (IsLastTestingWorkspace(testingWorkspaces)) {
-    return await EndTest(testingWorkspaces, ctx).catch(logErrorTest(ctx))
-  }
 
   try {
-    const testType = (await storage.getTestData(ctx)).testType
-    testingWorkspaces.Remove(workspaceName)
-    const testingParameters = createTestingParameters(testType, testingWorkspaces.ToArray())
-    await abTestRouter.setWorkspaces(account, {
-      id: testingWorkspaces.Id(),
-      workspaces: testingWorkspaces.ToArray(),
-    }).catch(logErrorTest(ctx))
-    const tsmap = new TSMap<string, ABTestParameters>([...testingParameters.Get()])
-    await abTestRouter.setParameters(account, {
-      Id: testingWorkspaces.Id(),
-      parameterPerWorkspace: tsmap,
-    }).catch(logErrorTest(ctx))
-    ctx.vtex.logger.info({ message: `A/B Test finished in ${account} for workspace ${workspaceName}`, account: `${account}`, workspace: `${workspaceName}`, method: 'TestFinished' })
-  } catch (err) {
-    if (err.status === 404) {
-      err.message = 'Workspace not found'
+
+    const testingWorkspaces = await abTestRouter.getWorkspaces(account)
+
+    if (testingWorkspaces.Length() === 0) {
+      ctx.response.status = 404
+      throw new NotFoundError(`Test not initialized for this account`)
     }
-    ctx.vtex.logger.error({ status: ctx.status, message: err.message })
+
+    if (IsLastTestingWorkspace(testingWorkspaces)) {
+      await EndTest(testingWorkspaces, ctx)
+    } 
+    else {
+      const testType = (await storage.getTestData(ctx)).testType
+      testingWorkspaces.Remove(workspaceName)
+      const testingParameters = createTestingParameters(testType, testingWorkspaces.ToArray())
+      await abTestRouter.setWorkspaces(account, {
+        id: testingWorkspaces.Id(),
+        workspaces: testingWorkspaces.ToArray(),
+      })
+      const tsmap = new TSMap<string, ABTestParameters>([...testingParameters.Get()])
+      await abTestRouter.setParameters(account, {
+        Id: testingWorkspaces.Id(),
+        parameterPerWorkspace: tsmap,
+      })
+      ctx.vtex.logger.info({ message: `A/B Test finished in ${account} for workspace ${workspaceName}`, account: `${account}`, workspace: `${workspaceName}`, method: 'TestFinished' })
+    }
+
+  } catch (err) {
+    err.message = 'Error finishing A/B test: ' + err.message
     throw err
   }
-}
-
-const logErrorTest = (ctx: Context) => (err: any) => {
-  if (err.status === 404) {
-    err.message = 'Test not found'
-  }
-  ctx.vtex.logger.error({ status: ctx.status, message: err.message })
-  throw err
 }
 
 const IsLastTestingWorkspace = (testingWorkspaces: TestingWorkspaces): boolean => {

--- a/node/abTest/endTest.ts
+++ b/node/abTest/endTest.ts
@@ -1,38 +1,21 @@
 import TestingWorkspaces from '../typings/testingWorkspace'
- import { TestWorkspaces } from './testWorkspaces'
- import { firstOrDefault } from '../utils/firstOrDefault'
+import { TestWorkspaces } from './testWorkspaces'
+import { firstOrDefault } from '../utils/firstOrDefault'
 
- export default async (testingWorkspaces: TestingWorkspaces, ctx: Context) => {
-     const { vtex: { account, route: { params: { finishingWorkspace } } }, clients: { abTestRouter, storage } } = ctx
-     const workspaceName = firstOrDefault(finishingWorkspace)
+export default async (testingWorkspaces: TestingWorkspaces, ctx: Context) => {
+  const { vtex: { account, route: { params: { finishingWorkspace } } }, clients: { abTestRouter, storage } } = ctx
+  const workspaceName = firstOrDefault(finishingWorkspace)
 
-     try {
-       await abTestRouter.deleteParameters(account).catch(logErrorTest(ctx))
-       await abTestRouter.deleteWorkspaces(account).catch(logErrorTest(ctx))
+  await abTestRouter.deleteParameters(account)
+  await abTestRouter.deleteWorkspaces(account)
 
-       const testData = await storage.getTestData(ctx).catch(logErrorTest(ctx))
-       const beginning = testData && testData.dateOfBeginning
-         ? testData.dateOfBeginning
-         : new Date().toISOString().substr(0, 16)
+  const testData = await storage.getTestData(ctx)
+  const beginning = testData && testData.dateOfBeginning
+    ? testData.dateOfBeginning
+    : new Date().toISOString().substr(0, 16)
 
-       const results = await TestWorkspaces(account, beginning, testingWorkspaces, ctx).catch(logErrorTest(ctx))
+  const results = await TestWorkspaces(account, beginning, testingWorkspaces, ctx)
 
-       await storage.finishABtest(ctx, results).catch(logErrorTest(ctx))
-       ctx.vtex.logger.info({ message: `A/B Test finished in ${account} for workspace ${workspaceName}`, account: `${account}`, workspace: `${workspaceName}`, method: 'TestFinished' })
-       return
-     } catch (err) {
-       if (err.status === 404) {
-         err.message = 'Workspace not found'
-       }
-       ctx.vtex.logger.error({ status: ctx.status, message: err.message })
-       throw err
-     } 
- }
-
- const logErrorTest = (ctx: Context) => (err: any) => {
-     if (err.status === 404) {
-       err.message = 'Test not found'
-     }
-     ctx.vtex.logger.error({ status: ctx.status, message: err.message })
-     throw err
- } 
+  await storage.finishABtest(ctx, results)
+  ctx.vtex.logger.info({ message: `A/B Test finished in ${account} for workspace ${workspaceName}`, account: `${account}`, workspace: `${workspaceName}`, method: 'TestFinished' })
+}

--- a/node/abTest/testWorkspaces.ts
+++ b/node/abTest/testWorkspaces.ts
@@ -17,24 +17,27 @@ export async function TestWorkspaces(account: string, abTestBeginning: string, t
 
             if (!HasWorkspacesData(workspacesData)) {
                 for (const workspaceName of testingWorkspaces.WorkspacesNames()) {
-                    if (workspaceName !== 'master') {
+                    if (workspaceName !== MasterWorkspaceName) {
                         Results.push(DefaultEvaluationResponseConversion(abTestBeginning, MasterWorkspaceName, workspaceName))
                     }
                 }
-                return Results
-            }
-            const workspacesCompleteData = await BuildCompleteData(account, abTestBeginning, workspacesData, storedash, abTestRouter)
-            const masterWorkspace = workspacesCompleteData.get(MasterWorkspaceName)
+            } else {
+                const workspacesCompleteData = await BuildCompleteData(account, abTestBeginning, workspacesData, storedash, abTestRouter)
+                const masterWorkspace = workspacesCompleteData.get(MasterWorkspaceName)
 
-            for (const workspaceData of workspacesCompleteData) {
-                if (workspaceData[0] !== MasterWorkspaceName) {
-                    Results.push(await Evaluate(abTestBeginning, masterWorkspace!, workspaceData[1]))
+                for (const workspaceData of workspacesCompleteData) {
+                    if (workspaceData[0] !== MasterWorkspaceName) {
+                        Results.push(await Evaluate(abTestBeginning, masterWorkspace!, workspaceData[1]))
+                    }
                 }
             }
         } catch (err) {
             err.message = 'Error evaluating test results: ' + err.message
             throw err
         }
+    }
+    if (Results.length === 0) {
+        throw new Error(`Error evaluating test's results: inconsistent data about initialized test`)
     }
     return Results
 }

--- a/node/clients/router.ts
+++ b/node/clients/router.ts
@@ -48,8 +48,13 @@ export default class Router extends InfraClient {
             throw err
         }
     }
-    public deleteParameters = (account: string) => {
-        return this.http.delete(routes.Parameters(account), { metric: 'abtest-delete-parameters' })
+    public deleteParameters = async (account: string) => {
+        try {
+            return await this.http.delete(routes.Parameters(account), { metric: 'abtest-delete-parameters' })
+        } catch (err) {
+            err.message = concatErrorMessages('Error deleting parameters from Router', err.message)
+            throw err
+        }
     }
 }
 

--- a/node/clients/router.ts
+++ b/node/clients/router.ts
@@ -40,8 +40,13 @@ export default class Router extends InfraClient {
         }
     }
 
-    public deleteWorkspaces = (account: string) => {
-        return this.http.delete(routes.Workspaces(account), { metric: 'abtest-delete-workspaces' })
+    public deleteWorkspaces = async (account: string) => {
+        try {
+            return await this.http.delete(routes.Workspaces(account), { metric: 'abtest-delete-workspaces' })
+        } catch (err) {
+            err.message = concatErrorMessages('Error deleting workspaces from Router', err.message)
+            throw err
+        }
     }
     public deleteParameters = (account: string) => {
         return this.http.delete(routes.Parameters(account), { metric: 'abtest-delete-parameters' })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Improve error handling throughout the finishing (of an A/B test) process by:
- Removing excessive `log`s along the way and
- Chaining clarifying error messages (in `err.message`), one for each step of the process.  These messages (i.e., the resulting `err.message`) are to be logged (by a command in `index.ts`) after the whole process is completed.

Each commit handles a specific function involved in the finishing process.
Functions already handled in previous PRs were left aside.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
