### PR TITLE
Remove excessive Add from InitializeAbTest

### DIFF
--- a/node/abTest/commands/initialize.ts
+++ b/node/abTest/commands/initialize.ts
@@ -38,7 +38,6 @@ async function InitializeAbTest(workspaceName: string, hoursOfInitialStage: numb
         }
         testingWorkspaces.Add(workspaceName)
         const testingParameters = createTestingParameters(testType, testingWorkspaces.ToArray())
-        testingParameters.Add(workspaceName)
         testingParameters.UpdateWithFixedParameters(proportionOfTraffic)
 
         await InitializeWorkspaces(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray())


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove unnecessary `testingParameters.Add(workspaceName)` from function `InitializeAbTest` of `node/abTest/commands/initialize.ts`. 

#### What problem is this solving?
The removed line didn't affect the code at all; removing it will avoid confusion. 

#### How should this be manually tested?
Initialize an A/B test and call its `status`, to verify whether the test has been initialized properly.  

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
