### PR TITLE
Round parameters for Router

### DIFF
--- a/node/typings/testingParameters.ts
+++ b/node/typings/testingParameters.ts
@@ -61,7 +61,7 @@ class TestingParametersConversion implements ITestingParameters{
 
         for (const workspace of this.parameters.keys()) {
             const parameter = workspace === MasterWorkspaceName ? actualProportion : nonMasterParameter
-            this.parameters.set(workspace, { a: parameter, b: 1 })
+            this.parameters.set(workspace, { a: Math.round(parameter), b: 1 })
         }
     }
 }
@@ -107,7 +107,7 @@ class TestingParametersRevenue implements ITestingParameters{
             sum += U
         }
         for (let i = 0; i < size; i++) {
-            this.parameters.set(testData.workspaceNames[i], {a:(testData.U[i]/sum), b:0})
+            this.parameters.set(testData.workspaceNames[i], { a: Math.round(testData.U[i]/sum), b: 0 })
         }
     }
 
@@ -118,7 +118,7 @@ class TestingParametersRevenue implements ITestingParameters{
 
         for (const workspace of this.parameters.keys()) {
             const parameter = workspace === MasterWorkspaceName ? actualProportion : nonMasterParameter
-            this.parameters.set(workspace, { a: parameter, b: 1 })
+            this.parameters.set(workspace, { a: Math.round(parameter), b: 1 })
         }
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Round the A/B test's parameters in the `update` functions. 
These functions are called always before saving the (new) parameters to the Router. 

#### What problem is this solving?
The Router expects the parameters to be integers! 

#### How should this be manually tested?
No test is necessary.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
