### PR TITLE
Save correct (initial) proportion to VBase

### DIFF
--- a/node/abTest/commands/initialize.ts
+++ b/node/abTest/commands/initialize.ts
@@ -13,9 +13,11 @@ export function InitializeAbTestForWorkspace(ctx: Context): Promise<void> {
 export function InitializeAbTestForWorkspaceWithParameters(ctx: Context): Promise<void> {
     const { vtex: { route: { params: { hours, proportion, initializingWorkspace } } }} = ctx
     const [ workspaceName, hoursOfInitialStage, proportionOfTraffic ] = [ initializingWorkspace, hours, proportion ].map(firstOrDefault)
-    checkIfNaN(hoursOfInitialStage, proportionOfTraffic)
     
-    return InitializeAbTest(workspaceName, Number(hoursOfInitialStage), Number(proportionOfTraffic), ctx)
+    checkIfNaN(hoursOfInitialStage, proportionOfTraffic)
+    const [ numberHours, numberProportion] = [ Number(hoursOfInitialStage), CheckProportion(Number(proportionOfTraffic))]
+    
+    return InitializeAbTest(workspaceName, numberHours, numberProportion, ctx)
 }
 
 export async function InitializeAbTestWithBodyParameters(ctx: Context): Promise<void> {
@@ -24,8 +26,9 @@ export async function InitializeAbTestWithBodyParameters(ctx: Context): Promise<
     const testType = Type as TestType
     
     checkIfNaN(hoursOfInitialStage, proportionOfTraffic)
+    const [ numberHours, numberProportion] = [ Number(hoursOfInitialStage), CheckProportion(Number(proportionOfTraffic))]
 
-    return InitializeAbTest(workspaceName, Number(hoursOfInitialStage), Number(proportionOfTraffic), ctx, testType)
+    return InitializeAbTest(workspaceName, numberHours, numberProportion, ctx, testType)
 }
 
 async function InitializeAbTest(workspaceName: string, hoursOfInitialStage: number, proportionOfTraffic: number, ctx: Context, testType: TestType = 'conversion'): Promise<void> {
@@ -76,3 +79,7 @@ const checkIfNaN = (hours: string, proportion: string) => {
         throw new Error(`Error reading proportion parameter: make sure to insert a number`)
     }
 } 
+
+const CheckProportion = (proportion: number): number => {
+    return proportion >= 0 && proportion <= 10000 ? Math.round(proportion) : 10000
+}

--- a/node/typings/testingParameters.ts
+++ b/node/typings/testingParameters.ts
@@ -55,12 +55,11 @@ class TestingParametersConversion implements ITestingParameters{
     }
 
     public UpdateWithFixedParameters = (proportion: number) => {
-        const actualProportion = CheckProportionBounds(proportion)
         const size = this.parameters.size
-        const nonMasterParameter = (10000 - actualProportion) / (size - 1)
+        const nonMasterParameter = (10000 - proportion) / (size - 1)
 
         for (const workspace of this.parameters.keys()) {
-            const parameter = workspace === MasterWorkspaceName ? actualProportion : nonMasterParameter
+            const parameter = workspace === MasterWorkspaceName ? proportion : nonMasterParameter
             this.parameters.set(workspace, { a: Math.round(parameter), b: 1 })
         }
     }
@@ -112,12 +111,11 @@ class TestingParametersRevenue implements ITestingParameters{
     }
 
     public UpdateWithFixedParameters = (proportion: number) => {
-        const actualProportion = CheckProportionBounds(proportion)
         const size = this.parameters.size
-        const nonMasterParameter = (10000 - actualProportion) / (size - 1)
+        const nonMasterParameter = (10000 - proportion) / (size - 1)
 
         for (const workspace of this.parameters.keys()) {
-            const parameter = workspace === MasterWorkspaceName ? actualProportion : nonMasterParameter
+            const parameter = workspace === MasterWorkspaceName ? proportion : nonMasterParameter
             this.parameters.set(workspace, { a: Math.round(parameter), b: 1 })
         }
     }
@@ -168,10 +166,6 @@ interface MannWhitneyTestData {
     OrdersValueHistory: number[][],
     U: number[],
 
-}
-
-const CheckProportionBounds = (proportion: number): number => {
-    return proportion >= 0 && proportion <= 10000 ? proportion : 10000
 }
 
 const MapInitialParameters = (workspaces: ABTestWorkspace[]): Map<string, ABTestParameters> => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Save the (test's) actual initial proportion in VBase, by performing the checks - bound checks and rounding - before the saving.
Also, stop performing the checks on the proportion in the update functions, as the latter will only be called henceforth to operate the calculations with correctly bounded and rounded proportion values.

#### What problem is this solving?
So far, we have been saving (in VBase) the number the user sets as the test's proportion, whether it is valid (integer, non-negative, smaller than 10001) or not. When such number is not valid, the actual initial proportion of the test is another number: either 10000, in case the proportion chosen by the user is negative or bigger than 10000, or the rounded version
of the problematically chosen number.

#### How should this be manually tested?
Call the initializing functions and verify whether the test is initialized with a proper proportion. This should be done:
1. by setting a valid proportion value;
2. by setting a negative proportion value;
3. by setting a proportion value bigger than 10000;
4. by setting a non-integer (yet respecting the bounds) proportion value.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
