### PR TITLE
Fix bugs in commands/update

### DIFF
--- a/node/abTest/commands/update.ts
+++ b/node/abTest/commands/update.ts
@@ -9,7 +9,7 @@ export async function UpdateStatusOnEvent(ctx: Context): Promise<void> {
       let beginning = testData.dateOfBeginning
       let hours = testData.initialStageTime
       let proportion = testData.initialProportion
-      if (!(beginning && hours && proportion)) {
+      if (!(beginning && proportion && hours !== undefined)) {
         beginning = new Date().toISOString().substr(0, 16)
         hours = 0
         proportion = 100

--- a/node/abTest/commands/update.ts
+++ b/node/abTest/commands/update.ts
@@ -12,7 +12,7 @@ export async function UpdateStatusOnEvent(ctx: Context): Promise<void> {
       if (!(beginning && proportion && hours !== undefined)) {
         beginning = new Date().toISOString().substr(0, 16)
         hours = 0
-        proportion = 100
+        proportion = 10000
       }
       const testType = testData.testType
       const workspacesData: WorkspaceData[] = (testType === 'revenue') ? await GetGranularData(ctx) : await storedash.getWorkspacesData(beginning)


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Stop using default parameters - when updating - only because the initial time was set to 0;
- Set the default proportion to 10000.

#### What problem is this solving?
When the test is updated, the app checks if there is any problem with the parameters and, if so, sets them to the default parameters values, to proceed the updating. So far, this resetting has been being executed no matter what when the initial time is 0, and this is not what we want: the initial time being 0 is not a problem at all. 
Also, the default value of the `proportion` parameter is `10000`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
