### PR TITLE
Fix GetGranularData

### DIFF
--- a/node/clients/storedash.ts
+++ b/node/clients/storedash.ts
@@ -68,7 +68,7 @@ export default class Storedash extends ExternalClient {
                     const m: StoreDashResponse = metrics[i] as unknown as StoreDashResponse
                     const workspaceData = workspacesData.get(m['workspace'])
                     if (workspaceData !== undefined) {
-                        workspaceData.OrdersValueHistory.push(CalculateOrdersValue(m['data.ordersValue'], m['data.sessionsOrdered']))
+                        workspaceData.OrdersValueHistory.push(...CalculateOrdersValue(m['data.ordersValue'], m['data.sessionsOrdered']))
                     }
                 }
                 dateFrom.setTime(dateTo.getTime())
@@ -82,10 +82,17 @@ export default class Storedash extends ExternalClient {
     }
 }
 
-const CalculateOrdersValue = (value: number, sessions: number): number => {
-    const sessionsCleaned = (sessions === NaN || sessions <= 0) ? 1 : sessions
-    const valueCleaned = (value === NaN || value <= 0) ? 0 : value
-    return (valueCleaned/sessionsCleaned)
+const CalculateOrdersValue = (value: number, sessions: number): number[] => {
+    let ordersValue: number[] = []
+
+    if (isNaN(value) || isNaN(sessions) || value <= 0 || sessions <= 0) {
+        return ordersValue
+    }
+    const avarageValue = value/sessions
+    for (let i = 0; i < Math.round(sessions); i++) {
+        ordersValue.push(avarageValue)
+    }
+    return ordersValue
 }
 
 const AggregationQueryFrom = (from: string): string => (


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make the `CalculateOrdersValue` function return either an empty array, in case no order was made or no money was spent, or  an array containing as many elements as the number of sessions, each element being equal to the average of money spent per session in the sessions under consideration.

#### What problem is this solving?
We want to have in hands - when doing the analysis - the set of orders' values (each value corresponding to one order and vice-versa), with no zero included. 
In the way `CalculateOrdersValue` worked, zero values might have been appearing, and orders might have been left aside: no matter how many orders we had in each `5` minutes window, the function returned one and exactly one value. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
