### PR TITLE
Check workspace name before initializing and finishing

### DIFF
--- a/node/abTest/commands/finish.ts
+++ b/node/abTest/commands/finish.ts
@@ -9,9 +9,16 @@ export async function FinishAbTestForWorkspace(ctx: Context): Promise<void> {
   const { vtex: { account, route: { params: { finishingWorkspace } } }, clients: { abTestRouter, storage } } = ctx
   const workspaceName = firstOrDefault(finishingWorkspace)
 
+  if (workspaceName === 'master') {
+    throw new Error(`Bad workspace name: the master workspace cannot be removed from the test`)
+  }
   try {
 
     const testingWorkspaces = await abTestRouter.getWorkspaces(account)
+
+    if (!(testingWorkspaces.Includes(workspaceName))) {
+      throw new Error(`Bad workspace name: make sure to select one of the workspaces under test`)
+    }
 
     if (testingWorkspaces.Length() === 0) {
       ctx.response.status = 404

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -7,6 +7,8 @@ declare global {
 
   type TestType = 'conversion' | 'revenue'
 
+  type UrlParameter = string | string[] | undefined
+
   interface WorkspaceData {
     Workspace: string
     Sessions: number

--- a/node/utils/BodyParser/getRequestParams.ts
+++ b/node/utils/BodyParser/getRequestParams.ts
@@ -6,7 +6,6 @@ export default async (ctx: Context) => {
     const bodyContent = await readBody(ctx)
     checkForExpectedFields(bodyContent)
     const { InitializingWorkspace, Hours, Proportion, Type } = bodyContent  
-    checkTestType(Type)
 
     return { InitializingWorkspace, Hours, Proportion, Type }
 }
@@ -17,11 +16,5 @@ const checkForExpectedFields = (object: object) => {
         if (!(field in object)) {
             throw new Error(`Error getting request's parameters: make sure to set the ${field} field`)
         }
-    }
-}
-
-const checkTestType = (Type: string) => {
-    if (Type !== 'conversion' && Type !== 'revenue') {
-        throw new Error(`Error setting test type: please make sure to spell it correctly (either 'conversion' or 'revenue')`)
     }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Avoid initializing a test with a non-existing workspace, with a development workspace or with the `master` workspace. 
- Throw an error when trying to remove (`finish`) from the test the master workspace or a workspace that was not under test.

#### What problem is this solving?
- When initializing a test with a non-existing or with the master workspace, problems would appear at the Router.
- When removing from the test a workspace that was not being tested (that could occur because of a misspelling, for example), the set of workspaces under test would remain the same, but the proportions would be reset. 

#### How should this be manually tested?
- Call the initializing routes, set as workspace: 
    1. a name that does not correspond to any of the account's workspaces;
    2. a development workspace;
    3.  the `master` workspace;
    4. a production workspace
and verify whether the app responds as expected*.
- Call the finishing route, set as workspace:
    1. a name that does not correspond to any of the account's workspaces;
    2. one of the account's workspaces that are not under test;
    3. the `master` workspace;
    4. one of the workspaces under test
and verify whether the app responds as expected*.

\* <sub>You should also call the test's `status` to check if everything went as intended.</sub> 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
