### PR TITLE
Feature / finish test all at once

### DIFF
--- a/node/abTest/commands/finish.ts
+++ b/node/abTest/commands/finish.ts
@@ -3,7 +3,23 @@ import { TSMap } from 'typescript-map'
 import { createTestingParameters } from '../../typings/testingParameters'
 import TestingWorkspaces from '../../typings/testingWorkspace'
 import { firstOrDefault } from '../../utils/firstOrDefault'
-import { EndTestForWorkspace } from '../endTest'
+import { EndTestForWorkspace, EndTest } from '../endTest'
+
+export async function FinishAbTest(ctx: Context): Promise<void> {
+  const { vtex: { account }, clients: {abTestRouter } } = ctx
+  try {
+    const testingWorkspaces = await abTestRouter.getWorkspaces(account)
+
+    if (testingWorkspaces.Length() === 0) {
+      ctx.status = 404
+      throw new NotFoundError(`Test not initialized for this account`)
+    }
+    await EndTest(testingWorkspaces, ctx)
+  } catch (err) {
+    err.message = 'Error finishing A/B test: ' + err.message
+    throw err
+  }
+}
 
 export async function FinishAbTestForWorkspace(ctx: Context): Promise<void> {
   const { vtex: { account, route: { params: { finishingWorkspace } } }, clients: { abTestRouter, storage } } = ctx

--- a/node/abTest/commands/finish.ts
+++ b/node/abTest/commands/finish.ts
@@ -3,7 +3,7 @@ import { TSMap } from 'typescript-map'
 import { createTestingParameters } from '../../typings/testingParameters'
 import TestingWorkspaces from '../../typings/testingWorkspace'
 import { firstOrDefault } from '../../utils/firstOrDefault'
-import EndTest from '../endTest'
+import { EndTestForWorkspace } from '../endTest'
 
 export async function FinishAbTestForWorkspace(ctx: Context): Promise<void> {
   const { vtex: { account, route: { params: { finishingWorkspace } } }, clients: { abTestRouter, storage } } = ctx
@@ -28,7 +28,7 @@ export async function FinishAbTestForWorkspace(ctx: Context): Promise<void> {
     }
 
     if (IsLastTestingWorkspace(testingWorkspaces)) {
-      await EndTest(testingWorkspaces, ctx)
+      await EndTestForWorkspace(testingWorkspaces, ctx)
     } 
     else {
       const testData = await storage.getTestData(ctx)

--- a/node/abTest/controller.ts
+++ b/node/abTest/controller.ts
@@ -1,5 +1,5 @@
 import { getWithRetriesHelper } from '../utils/getWithRetries'
-import { FinishAbTestForWorkspace as finish } from './commands/finish'
+import { FinishAbTestForWorkspace as finishForWorkspace, FinishAbTest as finish } from './commands/finish'
 import { InitializeAbTestForWorkspace as initialize, InitializeAbTestForWorkspaceWithParameters as initializeWithParameters, InitializeAbTestWithBodyParameters as initializeWithBodyParameters } from './commands/initialize'
 import { ABTestStatus as status } from './commands/status'
 import { TTCAbTest as timeToComplete } from './commands/timeToComplete'
@@ -60,6 +60,15 @@ export const abTestStatus = async (ctx: Context) => {
 }
 
 export const finishAbTestForWorkspace = async (ctx: Context) => {
+  ctx.set('Cache-Control', 'no-cache')
+
+  await getWithRetriesHelper(finishForWorkspace)(3, ctx)
+
+  ctx.status = 200
+  ctx.body = 'A/B Test finished for workspace'
+}
+
+export const finishAbTest = async (ctx: Context) => {
   ctx.set('Cache-Control', 'no-cache')
 
   await getWithRetriesHelper(finish)(3, ctx)

--- a/node/abTest/endTest.ts
+++ b/node/abTest/endTest.ts
@@ -20,3 +20,22 @@ export const EndTestForWorkspace = async (testingWorkspaces: TestingWorkspaces, 
   await storage.finishABtest(ctx, results)
   ctx.vtex.logger.info({ message: `A/B Test finished in ${account} for workspace ${workspaceName}`, account: `${account}`, workspace: `${workspaceName}`, method: 'TestFinished' })
 }
+
+export const EndTest = async (testingWorkspaces: TestingWorkspaces, ctx: Context) => {
+  const { vtex: { account }, clients: { abTestRouter, storage } } = ctx
+
+  await abTestRouter.deleteParameters(account)
+  await abTestRouter.deleteWorkspaces(account)
+
+  const testData = await storage.getTestData(ctx)
+  const beginning = testData && testData.dateOfBeginning
+    ? testData.dateOfBeginning
+    : new Date().toISOString().substr(0, 16)
+
+  const testType = testData.testType
+  const results = await TestWorkspaces(account, beginning, testingWorkspaces, testType, ctx)
+
+  await storage.finishABtest(ctx, results)
+
+  ctx.vtex.logger.info({ message: `A/B Test finished in account ${account}`, account: `${account}`, method: 'TestFinished' })
+}

--- a/node/abTest/endTest.ts
+++ b/node/abTest/endTest.ts
@@ -2,7 +2,7 @@ import TestingWorkspaces from '../typings/testingWorkspace'
 import { TestWorkspaces } from './testWorkspaces'
 import { firstOrDefault } from '../utils/firstOrDefault'
 
-export default async (testingWorkspaces: TestingWorkspaces, ctx: Context) => {
+export const EndTestForWorkspace = async (testingWorkspaces: TestingWorkspaces, ctx: Context) => {
   const { vtex: { account, route: { params: { finishingWorkspace } } }, clients: { abTestRouter, storage } } = ctx
   const workspaceName = firstOrDefault(finishingWorkspace)
 

--- a/node/abTest/updateParameters.ts
+++ b/node/abTest/updateParameters.ts
@@ -30,15 +30,15 @@ export async function UpdateParameters(ctx: Context, aBTestBeginning: string, ho
         let randomRestart: boolean = false
         for (const workspaceCompleteData of workspacesCompleteData) {
             randomRestart = workspaceCompleteData[0] === MasterWorkspaceName ? false : RandomRestart(workspaceCompleteData[1], masterWorkspace!)
-            if (!randomRestart) {
-                testingParameters.Update(MapWorkspaceData(workspacesData))
-                const tsmap = new TSMap<string, ABTestParameters>([...testingParameters.Get()])
-                await abTestRouter.setParameters(ctx.vtex.account, {
-                    Id: testId,
-                    parameterPerWorkspace: tsmap,
-                })
-                return
-            }
+        }
+        if (!randomRestart) {
+            testingParameters.Update(MapWorkspaceData(workspacesData))
+            const tsmap = new TSMap<string, ABTestParameters>([...testingParameters.Get()])
+            await abTestRouter.setParameters(ctx.vtex.account, {
+                Id: testId,
+                parameterPerWorkspace: tsmap,
+            })
+            return
         }
         await ResetParameters(ctx.vtex.account, testingWorkspaces.ToArray(), proportionOfTraffic, testType, testId, abTestRouter)
         await storage.initializeABtest(hoursOfInitialStage, proportionOfTraffic, testType, ctx)

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,6 +1,6 @@
 import { ClientsConfig, Service } from '@vtex/api'
 import { map } from 'ramda'
-import { abTestStatus, finishAbTestForWorkspace, initializeAbTestForWorkspace, initializeAbTestForWorkspaceWithParameters, LegacyInitializeAbTestForWorkspace, timeToCompleteAbTest, updateParameters, initializeAbTest } from './abTest/controller'
+import { abTestStatus, finishAbTestForWorkspace, finishAbTest, initializeAbTestForWorkspace, initializeAbTestForWorkspaceWithParameters, LegacyInitializeAbTestForWorkspace, timeToCompleteAbTest, updateParameters, initializeAbTest } from './abTest/controller'
 import { Clients } from './clients/index'
 
 const THREE_SECONDS_MS = 3000
@@ -65,6 +65,7 @@ export default new Service<Clients>({
       LegacyInitializeAbTestForWorkspace,
       abTestStatus,
       finishAbTestForWorkspace,
+      finishAbTest,
       initializeAbTestForWorkspace,
       initializeAbTestForWorkspaceWithParameters,
       initializeAbTest,

--- a/node/service.json
+++ b/node/service.json
@@ -29,6 +29,10 @@
     "finishAbTestForWorkspace": {
       "path": "/_v/private/abtesting/finish/:finishingWorkspace",
       "public": false
+    },
+    "finishAbTest": {
+      "path": "/_v/private/abtesting/finish",
+      "public": false
     }
   },
   "events": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Create a route that enables the user to finish the A/B test for all the workspaces with one only command.

#### What problem is this solving?
So far, the user has only been able to remove one workspace at a time from a running test.

#### How should this be manually tested?
- Initialize a test with several workspaces, call the route and ask for the test's `status`, to verify whether the test was finished properly;
- call the route without having any running test, to check whether the app throws the expected error.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
