### PR TITLE
Fix bayesian analysis of conversion

### DIFF
--- a/node/abTest/analysis/compareWorkspaces/bayesianConversion.ts
+++ b/node/abTest/analysis/compareWorkspaces/bayesianConversion.ts
@@ -1,7 +1,6 @@
 import { DefaultResponseBayesianConversion } from '../../../utils/evaluation-response/default'
 import { EvaluationResponseBayesianConversion } from '../../../utils/evaluation-response/evaluation'
 import { ChooseWinner, LossFunctionChoosingVariantOne, ProbabilityOfOneBeatsTwo } from '../../../utils/mathTools/decisionRule/bayesianConversion'
-import { BoundError } from '../../../utils/mathTools/forBetaDistribution/statistics/samplesRestrictions'
 import { WorkspaceToBetaDistribution } from '../../../utils/workspace'
 
 export function Evaluate(abTestBeginning: string, workspaceAData: WorkspaceCompleteData, workspaceBData: WorkspaceCompleteData): BayesianEvaluationResultConversion {
@@ -14,7 +13,7 @@ export function Evaluate(abTestBeginning: string, workspaceAData: WorkspaceCompl
     const lossA = LossFunctionChoosingVariantOne(betaDistributionA, betaDistributionB)
     const lossB = LossFunctionChoosingVariantOne(betaDistributionB, betaDistributionA)
     const probabilityAbeatsB = ProbabilityOfOneBeatsTwo(betaDistributionA.a, betaDistributionA.b, betaDistributionB.a, betaDistributionB.b)
-    const winner = ChooseWinner(workspaceAData.SinceBeginning, workspaceBData.SinceBeginning, BoundError) || 'Not yet decided'
+    const winner = ChooseWinner(workspaceAData.SinceBeginning, workspaceBData.SinceBeginning)
 
     return EvaluationResponseBayesianConversion(abTestBeginning, workspaceAData, workspaceBData, winner, probabilityAbeatsB, lossA, lossB)
 }
@@ -30,6 +29,6 @@ export function Winner(workspacesData: WorkspaceData[]): string {
 }
 
 function chooseBetter(workspaceA: WorkspaceData, workspaceB: WorkspaceData): WorkspaceData {
-    const better = ChooseWinner(workspaceA, workspaceB, BoundError)
+    const better = ChooseWinner(workspaceA, workspaceB)
     return better === workspaceB.Workspace ? workspaceB : workspaceA
 }

--- a/node/utils/mathTools/decisionRule/bayesianConversion.ts
+++ b/node/utils/mathTools/decisionRule/bayesianConversion.ts
@@ -1,8 +1,5 @@
 import { WorkspaceToBetaDistribution } from '../../workspace'
 import { logBeta } from '../forBetaDistribution/beta-function'
-import { pValue } from '../forBetaDistribution/statistics/samplesRestrictions'
-
-const Confidence = 0.95
 
 /*
 *   The reason for using the function logBeta is that we're dealing with very large numbers and the
@@ -101,26 +98,14 @@ export function LossFunctionChoosingVariantOne(Beta1: ABTestParameters, Beta2: A
     return Math.exp(logCoefficient1) * ProbabilityOfOneBeatsTwo(a + 1, b, c, d) - Math.exp(logCoefficient2) * ProbabilityOfOneBeatsTwo(a, b, c + 1, d)
 }
 
-export function ChooseWinner(WorkspaceA: WorkspaceData, WorkspaceB: WorkspaceData, epsilon: number) {
+export function ChooseWinner(WorkspaceA: WorkspaceData, WorkspaceB: WorkspaceData) {
     const betaA = WorkspaceToBetaDistribution(WorkspaceA)
     const betaB = WorkspaceToBetaDistribution(WorkspaceB)
-    const pvalue = pValue(betaA, betaB)
 
-    const chooseA = LossFunctionChoosingVariantOne(betaA, betaB) < epsilon
-    const chooseB = LossFunctionChoosingVariantOne(betaB, betaA) < epsilon
-    const draw = pvalue > Confidence
-    const distinct = pvalue < 1 - Confidence
+    const lossA = LossFunctionChoosingVariantOne(betaA, betaB)
+    const lossB = LossFunctionChoosingVariantOne(betaB, betaA)
 
-    if (chooseA && chooseB && draw) {
-        return 'draw'
-    }
-    else if (chooseA && distinct) {
-        return WorkspaceA.Workspace
-    }
-    else if (chooseB && distinct) {
-        return WorkspaceB.Workspace
-    }
-    else {
-        return null
-    }
+    if (lossA < lossB) return WorkspaceA.Workspace
+    if (lossA > lossB) return WorkspaceB.Workspace
+    return 'draw'
 }

--- a/node/utils/mathTools/forBetaDistribution/statistics/samplesRestrictions.ts
+++ b/node/utils/mathTools/forBetaDistribution/statistics/samplesRestrictions.ts
@@ -1,5 +1,3 @@
-import { betaDensity, incompleteBeta } from './betaDistribution'
-
 export const BoundError = 2e-4
 
 /*
@@ -11,28 +9,4 @@ export const BoundError = 2e-4
 
 export function NumberOfSamples(boundError: number, BoundProbability: number): number {
     return - Math.log(BoundProbability) / Math.pow(boundError, 2) / 36
-}
-
-export const pValue = (control: ABTestParameters, alternative: ABTestParameters): number => {
-    const alternativeConversion = (alternative.a - 1) / (alternative.a + alternative.b - 2)
-    return customBetaProbability(alternativeConversion, control.a, control.b)
-}
-
-const customBetaProbability = (x: number, a: number, b: number): number => {
-    const lambda = (a - 1) / (a + b - 2)
-    const lambda1 = lambda - BoundError
-    const a1 = 1 + Math.floor((lambda1 / lambda) * (a - 1))
-    const b1 = a + b - a1
-    const h = betaDensity(lambda, a, b)
-    const distance = Math.abs(x - lambda)
-
-    const totalMass = 1 + (2 * BoundError * h)
-
-    if (distance < BoundError) {
-        let probability = 1 / 2
-        probability += h * (BoundError - distance)
-        return (2 * probability) / totalMass
-    }
-
-    return (2 * incompleteBeta(lambda - distance, a1, b1)) / totalMass
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove everything related with `P-Value` calculations in the bayesian analysis of conversion. 

#### What problem is this solving?
Bayesian analyses make all the decisions based on `expected losses`. The concept of a `P-Value` does not make sense in the context of a bayesian analysis, once there is no uncertainty on the distributions we work with: all the probabilities we calculate during the analysis are unquestionably certain, given the priors we had and the events we observed.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
