### PR TITLE
Refactor parameters types

### DIFF
--- a/node/abTest/commands/finish.ts
+++ b/node/abTest/commands/finish.ts
@@ -1,7 +1,7 @@
 import { NotFoundError } from '@vtex/api'
 import TestingWorkspaces from '../../typings/testingWorkspace'
 import { firstOrDefault } from '../../utils/firstOrDefault'
-import { InitializeParameters, InitializeWorkspaces } from '../initialize-Router'
+import { InitializeProportions, InitializeWorkspaces } from '../initialize-Router'
 import { CheckFinishingWorkspace as CheckWorkspace } from '../../utils/Request/Checks'
 import { EndTestForWorkspace, EndTest } from '../endTest'
 
@@ -45,7 +45,7 @@ export async function FinishAbTestForWorkspace(ctx: Context): Promise<void> {
       const [ testType, testApproach, proportion, initialTime ] = [ testData.testType, testData.testApproach, testData.initialProportion, testData.initialStageTime ]
       
       await InitializeWorkspaces(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray())
-      await InitializeParameters(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray(), proportion)
+      await InitializeProportions(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray(), proportion)
       await storage.initializeABtest(initialTime, proportion, testType, testApproach, ctx)
 
       ctx.vtex.logger.info({ message: `A/B Test finished in ${account} for workspace ${workspaceName}`, account: `${account}`, workspace: `${workspaceName}`, method: 'TestFinished' })

--- a/node/abTest/commands/finish.ts
+++ b/node/abTest/commands/finish.ts
@@ -42,11 +42,11 @@ export async function FinishAbTestForWorkspace(ctx: Context): Promise<void> {
       const testingWorkspaces = new TestingWorkspaces({id: '', workspaces: currentWorkspaces.ToArray()})
 
       const testData = await storage.getTestData(ctx)
-      const [ testType, testApproach, proportion, initialTime ] = [ testData.testType, testData.testApproach, testData.initialProportion, testData.initialStageTime ]
+      const [ testType, testApproach, initialMasterProportion, initialTime ] = [ testData.testType, testData.testApproach, testData.initialProportion, testData.initialStageTime ]
       
       await InitializeWorkspaces(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray())
-      await InitializeProportions(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray(), proportion)
-      await storage.initializeABtest(initialTime, proportion, testType, testApproach, ctx)
+      await InitializeProportions(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray(), initialMasterProportion)
+      await storage.initializeABtest(initialTime, initialMasterProportion, testType, testApproach, ctx)
 
       ctx.vtex.logger.info({ message: `A/B Test finished in ${account} for workspace ${workspaceName}`, account: `${account}`, workspace: `${workspaceName}`, method: 'TestFinished' })
     }

--- a/node/abTest/commands/initialize.ts
+++ b/node/abTest/commands/initialize.ts
@@ -1,7 +1,7 @@
 import { firstOrDefault } from '../../utils/firstOrDefault'
 import getRequestParams from '../../utils/Request/getRequestParams'
 import { checkTestType, checkTestApproach, checkIfNaN, CheckProportion, CheckInitializingWorkspaces as CheckWorkspaces } from '../../utils/Request/Checks'
-import { InitializeParameters, InitializeWorkspaces } from '../initialize-Router'
+import { InitializeProportions, InitializeWorkspaces } from '../initialize-Router'
 import TestingWorkspaces from '../../typings/testingWorkspace'
 
 export function InitializeAbTestForWorkspace(ctx: Context): Promise<void> {
@@ -49,7 +49,7 @@ async function InitializeAbTest(workspacesNames: string[], hoursOfInitialStage: 
         for (const workspace of workspacesNames) {
             testingWorkspaces.Add(workspace)
         }
-        await InitializeParameters(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray(), proportionOfTraffic)
+        await InitializeProportions(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray(), proportionOfTraffic)
         await InitializeWorkspaces(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray())
         await storage.initializeABtest(hoursOfInitialStage, proportionOfTraffic, testType, approach, ctx)
         

--- a/node/abTest/commands/update.ts
+++ b/node/abTest/commands/update.ts
@@ -1,4 +1,4 @@
-import { UpdateParameters } from '../updateParameters'
+import { UpdateProportions } from '../updateProportions'
 
 export async function UpdateStatusOnEvent(ctx: Context): Promise<void> {
   const { vtex: { account, logger }, clients: { abTestRouter, storedash, storage } } = ctx
@@ -17,7 +17,7 @@ export async function UpdateStatusOnEvent(ctx: Context): Promise<void> {
       const testType = testData.testType
       const testApproach = testData.testApproach
       const workspacesData: WorkspaceData[] = (testType === 'revenue') ? await GetGranularData(ctx) : await storedash.getWorkspacesData(beginning)
-      await UpdateParameters(ctx, beginning, hours, proportion, workspacesData, testingWorkspaces, testingWorkspaces.Id() || 'noId', testType, testApproach)
+      await UpdateProportions(ctx, beginning, hours, proportion, workspacesData, testingWorkspaces, testingWorkspaces.Id() || 'noId', testType, testApproach)
     }
   } catch (err) {
     err.message = 'Error on test update: ' + err.message

--- a/node/abTest/commands/update.ts
+++ b/node/abTest/commands/update.ts
@@ -8,16 +8,16 @@ export async function UpdateStatusOnEvent(ctx: Context): Promise<void> {
       const testData = await storage.getTestData(ctx)
       let beginning = testData.dateOfBeginning
       let hours = testData.initialStageTime
-      let proportion = testData.initialProportion
-      if (!(beginning && proportion && hours !== undefined)) {
+      let initialMasterProportion = testData.initialProportion
+      if (!(beginning && initialMasterProportion && hours !== undefined)) {
         beginning = new Date().toISOString().substr(0, 16)
         hours = 0
-        proportion = 10000
+        initialMasterProportion = 10000
       }
       const testType = testData.testType
       const testApproach = testData.testApproach
       const workspacesData: WorkspaceData[] = (testType === 'revenue') ? await GetGranularData(ctx) : await storedash.getWorkspacesData(beginning)
-      await UpdateProportions(ctx, beginning, hours, proportion, workspacesData, testingWorkspaces, testingWorkspaces.Id() || 'noId', testType, testApproach)
+      await UpdateProportions(ctx, beginning, hours, initialMasterProportion, workspacesData, testingWorkspaces, testingWorkspaces.Id() || 'noId', testType, testApproach)
     }
   } catch (err) {
     err.message = 'Error on test update: ' + err.message

--- a/node/abTest/endTest.ts
+++ b/node/abTest/endTest.ts
@@ -6,7 +6,7 @@ export const EndTestForWorkspace = async (testingWorkspaces: TestingWorkspaces, 
   const { vtex: { account, route: { params: { finishingWorkspace } } }, clients: { abTestRouter, storage } } = ctx
   const workspaceName = firstOrDefault(finishingWorkspace)
 
-  await abTestRouter.deleteParameters(account)
+  await abTestRouter.deleteProportions(account)
   await abTestRouter.deleteWorkspaces(account)
 
   const testData = await storage.getTestData(ctx)
@@ -25,7 +25,7 @@ export const EndTestForWorkspace = async (testingWorkspaces: TestingWorkspaces, 
 export const EndTest = async (testingWorkspaces: TestingWorkspaces, ctx: Context) => {
   const { vtex: { account }, clients: { abTestRouter, storage } } = ctx
 
-  await abTestRouter.deleteParameters(account)
+  await abTestRouter.deleteProportions(account)
   await abTestRouter.deleteWorkspaces(account)
 
   const testData = await storage.getTestData(ctx)

--- a/node/abTest/initialize-Router.ts
+++ b/node/abTest/initialize-Router.ts
@@ -1,11 +1,11 @@
 import { TSMap } from 'typescript-map'
 import { createGenericTestingProportions } from '../typings/testingProportions'
 
-export async function InitializeProportions(ctx: Context, id: string, testingWorkspaces: ABTestWorkspace[], proportion: number): Promise<void> {
+export async function InitializeProportions(ctx: Context, id: string, testingWorkspaces: ABTestWorkspace[], masterProportion: number): Promise<void> {
     const [ router, account ] = [ ctx.clients.abTestRouter, ctx.vtex.account ]
 
     const testingProportions = createGenericTestingProportions(testingWorkspaces)
-    testingProportions.UpdateWithFixedProportions(proportion)
+    testingProportions.UpdateWithFixedProportions(masterProportion)
     const tsmap = new TSMap<string, proportion>([...testingProportions.Get()])
     
     await router.setProportions(account, {

--- a/node/abTest/initialize-Router.ts
+++ b/node/abTest/initialize-Router.ts
@@ -1,7 +1,7 @@
 import { TSMap } from 'typescript-map'
 import { createGenericTestingProportions } from '../typings/testingProportions'
 
-export async function InitializeParameters(ctx: Context, id: string, testingWorkspaces: ABTestWorkspace[], proportion: number): Promise<void> {
+export async function InitializeProportions(ctx: Context, id: string, testingWorkspaces: ABTestWorkspace[], proportion: number): Promise<void> {
     const [ router, account ] = [ ctx.clients.abTestRouter, ctx.vtex.account ]
 
     const testingProportions = createGenericTestingProportions(testingWorkspaces)

--- a/node/abTest/initialize-Router.ts
+++ b/node/abTest/initialize-Router.ts
@@ -1,12 +1,12 @@
 import { TSMap } from 'typescript-map'
-import { createGenericTestingParameters } from '../typings/testingParameters'
+import { createGenericTestingProportions } from '../typings/testingProportions'
 
 export async function InitializeParameters(ctx: Context, id: string, testingWorkspaces: ABTestWorkspace[], proportion: number): Promise<void> {
     const [ router, account ] = [ ctx.clients.abTestRouter, ctx.vtex.account ]
 
-    const testingParameters = createGenericTestingParameters(testingWorkspaces)
-    testingParameters.UpdateWithFixedParameters(proportion)
-    const tsmap = new TSMap<string, proportion>([...testingParameters.Get()])
+    const testingProportions = createGenericTestingProportions(testingWorkspaces)
+    testingProportions.UpdateWithFixedProportions(proportion)
+    const tsmap = new TSMap<string, proportion>([...testingProportions.Get()])
     
     await router.setParameters(account, {
         Id: id,

--- a/node/abTest/initialize-Router.ts
+++ b/node/abTest/initialize-Router.ts
@@ -6,7 +6,7 @@ export async function InitializeParameters(ctx: Context, id: string, testingWork
 
     const testingParameters = createGenericTestingParameters(testingWorkspaces)
     testingParameters.UpdateWithFixedParameters(proportion)
-    const tsmap = new TSMap<string, ABTestParameters>([...testingParameters.Get()])
+    const tsmap = new TSMap<string, proportion>([...testingParameters.Get()])
     
     await router.setParameters(account, {
         Id: id,

--- a/node/abTest/initialize-Router.ts
+++ b/node/abTest/initialize-Router.ts
@@ -8,7 +8,7 @@ export async function InitializeParameters(ctx: Context, id: string, testingWork
     testingProportions.UpdateWithFixedProportions(proportion)
     const tsmap = new TSMap<string, proportion>([...testingProportions.Get()])
     
-    await router.setParameters(account, {
+    await router.setProportions(account, {
         Id: id,
         parameterPerWorkspace: tsmap,
     })

--- a/node/abTest/updateParameters.ts
+++ b/node/abTest/updateParameters.ts
@@ -19,7 +19,7 @@ export async function UpdateParameters(ctx: Context, aBTestBeginning: string, ho
         if (await IsInitialStage(hoursOfInitialStage, workspacesData, storedash)) {
             testingProportions.UpdateWithFixedProportions(proportionOfTraffic)
             const tsmap = new TSMap<string, proportion>([...testingProportions.Get()])
-            await abTestRouter.setParameters(ctx.vtex.account, {
+            await abTestRouter.setProportions(ctx.vtex.account, {
                 Id: testId,
                 parameterPerWorkspace: tsmap,
             })
@@ -34,9 +34,9 @@ export async function UpdateParameters(ctx: Context, aBTestBeginning: string, ho
         if (!randomRestart) {
             testingProportions.Update(MapWorkspaceData(workspacesData))
             const tsmap = new TSMap<string, proportion>([...testingProportions.Get()])
-            await abTestRouter.setParameters(ctx.vtex.account, {
+            await abTestRouter.setProportions(ctx.vtex.account, {
                 Id: testId,
-                parameterPerWorkspace: tsmap,
+                proportionPerWorkspace: tsmap,
             })
             return
         }

--- a/node/abTest/updateParameters.ts
+++ b/node/abTest/updateParameters.ts
@@ -1,5 +1,5 @@
 import { TSMap } from 'typescript-map'
-import { createTestingParameters } from '../typings/testingParameters'
+import { createTestingProportions } from '../typings/testingProportions'
 import TestingWorkspaces from '../typings/testingWorkspace'
 import { RandomRestart } from '../utils/randomExploration'
 import { FilteredWorkspacesData } from '../utils/workspace'
@@ -14,11 +14,11 @@ export async function UpdateParameters(ctx: Context, aBTestBeginning: string, ho
     workspacesData: WorkspaceData[], testingWorkspaces: TestingWorkspaces, testId: string, testType: TestType, approach: TestApproach): Promise<void> {
     try { 
         const { clients: { abTestRouter, storedash, storage } } = ctx
-        const testingParameters = createTestingParameters(testType, approach, testingWorkspaces.ToArray())
+        const testingProportions = createTestingProportions(testType, approach, testingWorkspaces.ToArray())
 
         if (await IsInitialStage(hoursOfInitialStage, workspacesData, storedash)) {
-            testingParameters.UpdateWithFixedParameters(proportionOfTraffic)
-            const tsmap = new TSMap<string, proportion>([...testingParameters.Get()])
+            testingProportions.UpdateWithFixedProportions(proportionOfTraffic)
+            const tsmap = new TSMap<string, proportion>([...testingProportions.Get()])
             await abTestRouter.setParameters(ctx.vtex.account, {
                 Id: testId,
                 parameterPerWorkspace: tsmap,
@@ -32,8 +32,8 @@ export async function UpdateParameters(ctx: Context, aBTestBeginning: string, ho
             randomRestart = workspaceCompleteData[0] === MasterWorkspaceName ? false : RandomRestart(workspaceCompleteData[1], masterWorkspace!)
         }
         if (!randomRestart) {
-            testingParameters.Update(MapWorkspaceData(workspacesData))
-            const tsmap = new TSMap<string, proportion>([...testingParameters.Get()])
+            testingProportions.Update(MapWorkspaceData(workspacesData))
+            const tsmap = new TSMap<string, proportion>([...testingProportions.Get()])
             await abTestRouter.setParameters(ctx.vtex.account, {
                 Id: testId,
                 parameterPerWorkspace: tsmap,

--- a/node/abTest/updateParameters.ts
+++ b/node/abTest/updateParameters.ts
@@ -18,7 +18,7 @@ export async function UpdateParameters(ctx: Context, aBTestBeginning: string, ho
 
         if (await IsInitialStage(hoursOfInitialStage, workspacesData, storedash)) {
             testingParameters.UpdateWithFixedParameters(proportionOfTraffic)
-            const tsmap = new TSMap<string, ABTestParameters>([...testingParameters.Get()])
+            const tsmap = new TSMap<string, proportion>([...testingParameters.Get()])
             await abTestRouter.setParameters(ctx.vtex.account, {
                 Id: testId,
                 parameterPerWorkspace: tsmap,
@@ -33,7 +33,7 @@ export async function UpdateParameters(ctx: Context, aBTestBeginning: string, ho
         }
         if (!randomRestart) {
             testingParameters.Update(MapWorkspaceData(workspacesData))
-            const tsmap = new TSMap<string, ABTestParameters>([...testingParameters.Get()])
+            const tsmap = new TSMap<string, proportion>([...testingParameters.Get()])
             await abTestRouter.setParameters(ctx.vtex.account, {
                 Id: testId,
                 parameterPerWorkspace: tsmap,

--- a/node/abTest/updateParameters.ts
+++ b/node/abTest/updateParameters.ts
@@ -6,7 +6,7 @@ import { FilteredWorkspacesData } from '../utils/workspace'
 import { MapWorkspaceData } from '../utils/workspacesInfo/workspaceData'
 import { IsInitialStage } from './analysis/time/initialStage'
 import { BuildCompleteData } from './data/buildData'
-import { InitializeParameters } from './initialize-Router'
+import { InitializeProportions } from './initialize-Router'
 
 const MasterWorkspaceName = 'master'
 
@@ -40,7 +40,7 @@ export async function UpdateParameters(ctx: Context, aBTestBeginning: string, ho
             })
             return
         }
-        await InitializeParameters(ctx, testId, testingWorkspaces.ToArray(), proportionOfTraffic)
+        await InitializeProportions(ctx, testId, testingWorkspaces.ToArray(), proportionOfTraffic)
         await storage.initializeABtest(hoursOfInitialStage, proportionOfTraffic, testType, approach, ctx)
 
     } catch (err) {

--- a/node/abTest/updateProportions.ts
+++ b/node/abTest/updateProportions.ts
@@ -10,14 +10,14 @@ import { InitializeProportions } from './initialize-Router'
 
 const MasterWorkspaceName = 'master'
 
-export async function UpdateProportions(ctx: Context, aBTestBeginning: string, hoursOfInitialStage: number, proportionOfTraffic: number,
+export async function UpdateProportions(ctx: Context, aBTestBeginning: string, hoursOfInitialStage: number, masterProportion: number,
     workspacesData: WorkspaceData[], testingWorkspaces: TestingWorkspaces, testId: string, testType: TestType, approach: TestApproach): Promise<void> {
     try { 
         const { clients: { abTestRouter, storedash, storage } } = ctx
         const testingProportions = createTestingProportions(testType, approach, testingWorkspaces.ToArray())
 
         if (await IsInitialStage(hoursOfInitialStage, workspacesData, storedash)) {
-            testingProportions.UpdateWithFixedProportions(proportionOfTraffic)
+            testingProportions.UpdateWithFixedProportions(masterProportion)
             const tsmap = new TSMap<string, proportion>([...testingProportions.Get()])
             await abTestRouter.setProportions(ctx.vtex.account, {
                 Id: testId,
@@ -40,8 +40,8 @@ export async function UpdateProportions(ctx: Context, aBTestBeginning: string, h
             })
             return
         }
-        await InitializeProportions(ctx, testId, testingWorkspaces.ToArray(), proportionOfTraffic)
-        await storage.initializeABtest(hoursOfInitialStage, proportionOfTraffic, testType, approach, ctx)
+        await InitializeProportions(ctx, testId, testingWorkspaces.ToArray(), masterProportion)
+        await storage.initializeABtest(hoursOfInitialStage, masterProportion, testType, approach, ctx)
 
     } catch (err) {
         err.message = 'Error updating proportions: ' + err.message

--- a/node/abTest/updateProportions.ts
+++ b/node/abTest/updateProportions.ts
@@ -10,7 +10,7 @@ import { InitializeProportions } from './initialize-Router'
 
 const MasterWorkspaceName = 'master'
 
-export async function UpdateParameters(ctx: Context, aBTestBeginning: string, hoursOfInitialStage: number, proportionOfTraffic: number,
+export async function UpdateProportions(ctx: Context, aBTestBeginning: string, hoursOfInitialStage: number, proportionOfTraffic: number,
     workspacesData: WorkspaceData[], testingWorkspaces: TestingWorkspaces, testId: string, testType: TestType, approach: TestApproach): Promise<void> {
     try { 
         const { clients: { abTestRouter, storedash, storage } } = ctx
@@ -36,7 +36,7 @@ export async function UpdateParameters(ctx: Context, aBTestBeginning: string, ho
             const tsmap = new TSMap<string, proportion>([...testingProportions.Get()])
             await abTestRouter.setProportions(ctx.vtex.account, {
                 Id: testId,
-                proportionPerWorkspace: tsmap,
+                parameterPerWorkspace: tsmap,
             })
             return
         }
@@ -44,7 +44,7 @@ export async function UpdateParameters(ctx: Context, aBTestBeginning: string, ho
         await storage.initializeABtest(hoursOfInitialStage, proportionOfTraffic, testType, approach, ctx)
 
     } catch (err) {
-        err.message = 'Error updating parameters: ' + err.message
+        err.message = 'Error updating proportions: ' + err.message
         throw err
     }
 }

--- a/node/clients/router.ts
+++ b/node/clients/router.ts
@@ -4,7 +4,7 @@ import TestingWorkspaces from '../typings/testingWorkspace'
 import { concatErrorMessages } from '../utils/errorHandling'
 
 const routes = {
-    Parameters: (account: string) => `/${account}/_abtest/parameters`,
+    Proportions: (account: string) => `/${account}/_abtest/parameters`,
     Workspaces: (account: string) => `/${account}/_abtest/workspaces`,
 }
 
@@ -31,11 +31,11 @@ export default class Router extends InfraClient {
             throw err
         }
     }
-    public setParameters = async (account: string, metadata: Partial<ABTestMetadata>) => {
+    public setProportions = async (account: string, metadata: Partial<ABTestMetadata>) => {
         try {
-            return await this.http.put(routes.Parameters(account), metadata, { metric: 'abtest-set-parameters' })
+            return await this.http.put(routes.Proportions(account), metadata, { metric: 'abtest-set-parameters' })
         } catch (err) {
-            err.message = concatErrorMessages('Error setting parameteres to Router', err.message)
+            err.message = concatErrorMessages('Error setting proportions to Router', err.message)
             throw err
         }
     }
@@ -48,11 +48,11 @@ export default class Router extends InfraClient {
             throw err
         }
     }
-    public deleteParameters = async (account: string) => {
+    public deleteProportions = async (account: string) => {
         try {
-            return await this.http.delete(routes.Parameters(account), { metric: 'abtest-delete-parameters' })
+            return await this.http.delete(routes.Proportions(account), { metric: 'abtest-delete-parameters' })
         } catch (err) {
-            err.message = concatErrorMessages('Error deleting parameters from Router', err.message)
+            err.message = concatErrorMessages('Error deleting proportions from Router', err.message)
             throw err
         }
     }

--- a/node/clients/router.ts
+++ b/node/clients/router.ts
@@ -60,5 +60,5 @@ export default class Router extends InfraClient {
 
 interface ABTestMetadata {
     Id: string
-    parameterPerWorkspace: TSMap<string, ABTestParameters>
+    parameterPerWorkspace: TSMap<string, proportion>
 }

--- a/node/clients/vbase.ts
+++ b/node/clients/vbase.ts
@@ -52,7 +52,7 @@ export default class VBase extends BaseClient {
     }
   }
 
-  public initializeABtest = async (initialTime: number, proportion: number, testType: TestType, approach: TestApproach, ctx: Context) => {
+  public initializeABtest = async (initialTime: number, masterProportion: number, testType: TestType, approach: TestApproach, ctx: Context) => {
     const beginning = new Date().toISOString().substr(0, 16)
     try {
       const initialCache = InitialWorkspaceDataCache(new Date())
@@ -64,7 +64,7 @@ export default class VBase extends BaseClient {
     try {
       await this.save({
         dateOfBeginning: beginning,
-        initialProportion: proportion,
+        initialProportion: masterProportion,
         initialStageTime: initialTime,
         testType: testType,
         testApproach: approach

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -108,6 +108,8 @@ declare global {
     UpLiftChoosingB: number
   }
 
+  type proportion = number
+
   interface ABTestParameters {
     a: number
     b: number

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -114,4 +114,8 @@ declare global {
     a: number
     b: number
   }
+
+  interface BayesianRevenueParams extends BetaParameters {
+    r: number   // revenue per conversion
+  }
 }

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -110,7 +110,7 @@ declare global {
 
   type proportion = number
 
-  interface ABTestParameters {
+  interface BetaParameters {
     a: number
     b: number
   }

--- a/node/typings/testingProportions.ts
+++ b/node/typings/testingProportions.ts
@@ -56,7 +56,7 @@ class TestingProportionsBayesianConversion extends GenericTestingProportions imp
 
     public Update = (workspacesData: Map<string, WorkspaceData>) => {
         const names = Array<string>(0)
-        const betaParams = Array<ABTestParameters>(0)
+        const betaParams = Array<BetaParameters>(0)
 
         for (const workspace of this.proportions.keys()) {
             if (workspacesData.has(workspace)) {

--- a/node/typings/testingProportions.ts
+++ b/node/typings/testingProportions.ts
@@ -1,6 +1,6 @@
 import { ProbabilityYBeatsAll } from '../utils/mathTools/decisionRule/bayesianConversion'
 import { CalculateUValue } from '../utils/mathTools/decisionRule/frequentistRevenue'
-import { InitialABTestProportion, WorkspaceToBetaDistribution } from '../utils/workspace'
+import { MapInitialProportion, InitialABTestProportion, WorkspaceToBetaDistribution } from '../utils/workspace'
 
 const MasterWorkspaceName = 'master'
 
@@ -108,14 +108,6 @@ interface MannWhitneyTestData {
     OrdersValueHistory: number[][],
     U: number[],
 
-}
-
-const MapInitialProportion = (workspaces: ABTestWorkspace[]): Map<string, proportion> => {
-    const map = new Map()
-    for (const workspace of workspaces) {
-        map.set(workspace.name, InitialABTestProportion)
-    }
-    return map
 }
 
 const testingProportionsClasses = {

--- a/node/utils/mathTools/decisionRule/bayesianConversion.ts
+++ b/node/utils/mathTools/decisionRule/bayesianConversion.ts
@@ -18,7 +18,7 @@ export function ProbabilityOfOneBeatsTwo(a: number, b: number, c: number, d: num
     return result
 }
 
-function ProbabilityAllBeatsY(Y: ABTestParameters, X: Array<ABTestParameters>, idxs: Array<number>, next: number) {
+function ProbabilityAllBeatsY(Y: BetaParameters, X: Array<BetaParameters>, idxs: Array<number>, next: number) {
     let x = Y.a
     let y = Y.b
     for (let i = 0; i < idxs.length; i++) {
@@ -59,7 +59,7 @@ function NextComb(v: Array<number>) {
     }
 }
 
-export function ProbabilityYBeatsAll(Y: ABTestParameters, X: Array<ABTestParameters>) {
+export function ProbabilityYBeatsAll(Y: BetaParameters, X: Array<BetaParameters>) {
     let ret = 1
     let els = Array<number>(X.length)
     for (let i = 0; i < els.length; i++) {
@@ -69,7 +69,7 @@ export function ProbabilityYBeatsAll(Y: ABTestParameters, X: Array<ABTestParamet
     for (let i = 0; i < maxi; i++) {
         let curr = 0
         NextComb(els)
-        let CurrX = Array<ABTestParameters>(0)
+        let CurrX = Array<BetaParameters>(0)
         let idxs = []
         for (let j = 0; j < els.length; j++) {
             if (els[j] === 1) {
@@ -85,7 +85,7 @@ export function ProbabilityYBeatsAll(Y: ABTestParameters, X: Array<ABTestParamet
     return Math.round(ret)
 }
 
-export function LossFunctionChoosingVariantOne(Beta1: ABTestParameters, Beta2: ABTestParameters) {
+export function LossFunctionChoosingVariantOne(Beta1: BetaParameters, Beta2: BetaParameters) {
     const a = Beta2.a
     const b = Beta2.b
     const c = Beta1.a

--- a/node/utils/mathTools/decisionRule/bayesianConversion.ts
+++ b/node/utils/mathTools/decisionRule/bayesianConversion.ts
@@ -82,8 +82,7 @@ export function ProbabilityYBeatsAll(Y: ABTestParameters, X: Array<ABTestParamet
         ret += curr
     }
     ret *= 10000
-    ret = Math.round(ret)
-    return {a:ret, b:1}
+    return Math.round(ret)
 }
 
 export function LossFunctionChoosingVariantOne(Beta1: ABTestParameters, Beta2: ABTestParameters) {

--- a/node/utils/mathTools/decisionRule/bayesianRevenue.ts
+++ b/node/utils/mathTools/decisionRule/bayesianRevenue.ts
@@ -3,7 +3,7 @@ import { betaDensity } from '../forBetaDistribution/statistics/betaDistribution'
 import { calculateBound, has0or1Probability } from '../forBetaDistribution/statistics/densityEstimations'
 import { positiveRevenueWorkspaces, WorkspaceToBetaDistribution } from '../../workspace'
 
-export function ProbabilityXIsBest(X: ABTestParameters, Others: ABTestParameters[], rX: number, rOthers: number[]) {
+export function ProbabilityXIsBest(X: BetaParameters, Others: BetaParameters[], rX: number, rOthers: number[]) {
     if (rX === 0) return 0
 
     const [relevantWorkspaces, revenues] = positiveRevenueWorkspaces(Others, rOthers)
@@ -20,7 +20,7 @@ export function ProbabilityXIsBest(X: ABTestParameters, Others: ABTestParameters
     return probabilityUnderDiagonal(densityX, densitiesOthers, r, boundX, boundsOthers)
 }
 
-export function LossChoosingB(A: ABTestParameters, B: ABTestParameters, rA: number, rB: number) {
+export function LossChoosingB(A: BetaParameters, B: BetaParameters, rA: number, rB: number) {
     if (rA === 0) return 0
     if (rB === 0) return rA * A.a/(A.a+A.b)
 

--- a/node/utils/mathTools/decisionRule/bayesianRevenue.ts
+++ b/node/utils/mathTools/decisionRule/bayesianRevenue.ts
@@ -1,13 +1,13 @@
 import { probabilityUnderDiagonal, differenceExpectationUnderDiagonal } from '../riemannIntegration'
 import { betaDensity } from '../forBetaDistribution/statistics/betaDistribution'
 import { calculateBound, has0or1Probability } from '../forBetaDistribution/statistics/densityEstimations'
-import { positiveRevenueWorkspaces, WorkspaceToBetaDistribution } from '../../workspace'
+import { positiveRevenueWorkspaces, WorkspaceToBayesRevParameters } from '../../workspace'
 
-export function ProbabilityXIsBest(X: BetaParameters, Others: BetaParameters[], rX: number, rOthers: number[]) {
-    if (rX === 0) return 0
+export function ProbabilityXIsBest(X: BayesianRevenueParams, Others: BayesianRevenueParams[]) {
+    if (X.r === 0) return 0
 
-    const [relevantWorkspaces, revenues] = positiveRevenueWorkspaces(Others, rOthers)
-    const r = revenues.map((rev: number) => rX/rev)
+    const relevantWorkspaces = positiveRevenueWorkspaces(Others)
+    const r = relevantWorkspaces.map(workspace => X.r / workspace.r)
     const boundX = calculateBound(X.a, X.b)
     const boundsOthers = relevantWorkspaces.map((workspace) => calculateBound(workspace.a, workspace.b))
 
@@ -20,28 +20,28 @@ export function ProbabilityXIsBest(X: BetaParameters, Others: BetaParameters[], 
     return probabilityUnderDiagonal(densityX, densitiesOthers, r, boundX, boundsOthers)
 }
 
-export function LossChoosingB(A: BetaParameters, B: BetaParameters, rA: number, rB: number) {
-    if (rA === 0) return 0
-    if (rB === 0) return rA * A.a/(A.a+A.b)
+export function LossChoosingB(A: BayesianRevenueParams, B: BayesianRevenueParams) {
+    if (A.r === 0) return 0
+    if (B.r === 0) return A.r * A.a/(A.a+A.b)
 
     const boundA = calculateBound(A.a, A.b)
     const boundB = calculateBound(B.a, B.b)
 
-    const fastResult = has0or1Probability(A, [B], boundA, [boundB], [rA/rB])
-    if (fastResult[0]) return fastResult[1] * (rA * A.a/(A.a+A.b) - rB * B.a/(B.a+B.b))
+    const fastResult = has0or1Probability(A, [B], boundA, [boundB], [A.r/B.r])
+    if (fastResult[0]) return fastResult[1] * (A.r * A.a/(A.a+A.b) - B.r * B.a/(B.a+B.b))
 
     const densityA = (x: number) => betaDensity(x, A.a, A.b)
     const densityB = (y: number) => betaDensity(y, B.a, B.b)
 
-    return differenceExpectationUnderDiagonal(densityA, densityB, rA, rB, boundA, boundB)
+    return differenceExpectationUnderDiagonal(densityA, densityB, A.r, B.r, boundA, boundB)
 }
 
-export function PickWinner(WorkspaceA: WorkspaceData, WorkspaceB: WorkspaceData, rA: number, rB: number): string {
-    const A = WorkspaceToBetaDistribution(WorkspaceA)
-    const B = WorkspaceToBetaDistribution(WorkspaceB)
+export function PickWinner(WorkspaceA: WorkspaceData, WorkspaceB: WorkspaceData): string {
+    const A = WorkspaceToBayesRevParameters(WorkspaceA)
+    const B = WorkspaceToBayesRevParameters(WorkspaceB)
 
-    const lossA = LossChoosingB(B, A, rB, rA)
-    const lossB = LossChoosingB(A, B, rA, rB)
+    const lossA = LossChoosingB(B, A)
+    const lossB = LossChoosingB(A, B)
 
     if (lossA < lossB) return WorkspaceA.Workspace
     if (lossA > lossB) return WorkspaceB.Workspace

--- a/node/utils/mathTools/forBetaDistribution/statistics/betaSampling.ts
+++ b/node/utils/mathTools/forBetaDistribution/statistics/betaSampling.ts
@@ -1,6 +1,6 @@
 // The next algorithm is due to Cheng in Generating Beta Variates with Nonintegral Parameters
 
-export const RandomBeta = (betaVariable: ABTestParameters): number => {
+export const RandomBeta = (betaVariable: BetaParameters): number => {
     const a = betaVariable.a
     const b = betaVariable.b
     const ratio = a / b

--- a/node/utils/mathTools/forBetaDistribution/statistics/densityEstimations.ts
+++ b/node/utils/mathTools/forBetaDistribution/statistics/densityEstimations.ts
@@ -14,7 +14,7 @@ const error = 1e-4
 // interval belong to such set, we can assume we are integrating over (0,1) x (0,1).
 // On the other hand, if none of the points in the significant interval satisfy the inequality,
 // the integration amounts to approximately - with extremely small error - zero.
-export function has0or1Probability(X: ABTestParameters, Others: ABTestParameters[], boundX: number, boundsOthers: number[], r: number[]): [boolean, number] {
+export function has0or1Probability(X: BetaParameters, Others: BetaParameters[], boundX: number, boundsOthers: number[], r: number[]): [boolean, number] {
     const lowerBoundX = calculateLowerBound(X.a, X.b)
 
     for (const i in Others) {

--- a/node/utils/workspace.ts
+++ b/node/utils/workspace.ts
@@ -1,7 +1,6 @@
 import { TSMap } from 'typescript-map'
 
 export const InitialABTestParameters: ABTestParameters = { a: 1, b: 1 }
-export const DefaultABTestParameters: ABTestParameters = { a: 0, b: 0 }
 
 export const WorkspaceToBetaDistribution = (Workspace: WorkspaceData): ABTestParameters => ({
     a: Workspace.OrderSessions + 1,

--- a/node/utils/workspace.ts
+++ b/node/utils/workspace.ts
@@ -58,11 +58,11 @@ export function GetWorkspaceData(workspacesData: WorkspaceData[], workspace: str
 }
 
 export const InitialProportion = (workspaces: ABTestWorkspace[]): TSMap<string, proportion> => {
-    const parameters = new TSMap<string, proportion>()
+    const proportions = new TSMap<string, proportion>()
     for (const workspace of workspaces) {
-        parameters.set(workspace.name, InitialABTestProportion)
+        proportions.set(workspace.name, InitialABTestProportion)
     }
-    return parameters
+    return proportions
 }
 
 // Return only the workspaces of positive revenue

--- a/node/utils/workspace.ts
+++ b/node/utils/workspace.ts
@@ -7,6 +7,11 @@ export const WorkspaceToBetaDistribution = (Workspace: WorkspaceData): BetaParam
     b: Workspace.NoOrderSessions + 1,
 })
 
+export const WorkspaceToBayesRevParameters = (Workspace: WorkspaceData): BayesianRevenueParams => ({
+    ...WorkspaceToBetaDistribution(Workspace),
+    r: Workspace.OrdersValue / Workspace.OrderSessions
+})
+
 export const WorkspaceData = (Workspace: string, TotalSessions: number, OrderSessions: number, OrdersValue: number): WorkspaceData => ({
     Conversion: (TotalSessions > 0 ? OrderSessions / TotalSessions : 0),
     NoOrderSessions: (TotalSessions - OrderSessions),
@@ -66,8 +71,6 @@ export const InitialProportion = (workspaces: ABTestWorkspace[]): TSMap<string, 
 }
 
 // Return only the workspaces of positive revenue
-export function positiveRevenueWorkspaces(workspaces: BetaParameters[], averageRevenues: number[]): [BetaParameters[], number[]] {
-    const filteredWorkspaces = workspaces.filter((_workspace, idx) => averageRevenues[idx] > 0)
-    const filteredRevenues = averageRevenues.filter((revenue => revenue > 0))
-    return [ filteredWorkspaces, filteredRevenues ]
+export function positiveRevenueWorkspaces(workspaces: BayesianRevenueParams[]): BayesianRevenueParams[] {
+    return workspaces.filter(workspace => workspace.r > 0)
 }

--- a/node/utils/workspace.ts
+++ b/node/utils/workspace.ts
@@ -2,7 +2,7 @@ import { TSMap } from 'typescript-map'
 
 export const InitialABTestProportion: proportion = 1
 
-export const WorkspaceToBetaDistribution = (Workspace: WorkspaceData): ABTestParameters => ({
+export const WorkspaceToBetaDistribution = (Workspace: WorkspaceData): BetaParameters => ({
     a: Workspace.OrderSessions + 1,
     b: Workspace.NoOrderSessions + 1,
 })
@@ -66,7 +66,7 @@ export const InitialProportion = (workspaces: ABTestWorkspace[]): TSMap<string, 
 }
 
 // Return only the workspaces of positive revenue
-export function positiveRevenueWorkspaces(workspaces: ABTestParameters[], averageRevenues: number[]): [ABTestParameters[], number[]] {
+export function positiveRevenueWorkspaces(workspaces: BetaParameters[], averageRevenues: number[]): [BetaParameters[], number[]] {
     const filteredWorkspaces = workspaces.filter((_workspace, idx) => averageRevenues[idx] > 0)
     const filteredRevenues = averageRevenues.filter((revenue => revenue > 0))
     return [ filteredWorkspaces, filteredRevenues ]

--- a/node/utils/workspace.ts
+++ b/node/utils/workspace.ts
@@ -1,6 +1,6 @@
 import { TSMap } from 'typescript-map'
 
-export const InitialABTestParameters: ABTestParameters = { a: 1, b: 1 }
+export const InitialABTestProportion: proportion = 1
 
 export const WorkspaceToBetaDistribution = (Workspace: WorkspaceData): ABTestParameters => ({
     a: Workspace.OrderSessions + 1,
@@ -57,10 +57,10 @@ export function GetWorkspaceData(workspacesData: WorkspaceData[], workspace: str
     return ErrorWorkspaceData(workspace)
 }
 
-export const InitialParameters = (workspaces: ABTestWorkspace[]): TSMap<string, ABTestParameters> => {
-    const parameters = new TSMap<string, ABTestParameters>()
+export const InitialProportion = (workspaces: ABTestWorkspace[]): TSMap<string, proportion> => {
+    const parameters = new TSMap<string, proportion>()
     for (const workspace of workspaces) {
-        parameters.set(workspace.name, InitialABTestParameters)
+        parameters.set(workspace.name, InitialABTestProportion)
     }
     return parameters
 }

--- a/node/utils/workspace.ts
+++ b/node/utils/workspace.ts
@@ -1,5 +1,3 @@
-import { TSMap } from 'typescript-map'
-
 export const InitialABTestProportion: proportion = 1
 
 export const WorkspaceToBetaDistribution = (Workspace: WorkspaceData): BetaParameters => ({
@@ -62,8 +60,8 @@ export function GetWorkspaceData(workspacesData: WorkspaceData[], workspace: str
     return ErrorWorkspaceData(workspace)
 }
 
-export const InitialProportion = (workspaces: ABTestWorkspace[]): TSMap<string, proportion> => {
-    const proportions = new TSMap<string, proportion>()
+export const MapInitialProportion = (workspaces: ABTestWorkspace[]): Map<string, proportion> => {
+    const proportions = new Map<string, proportion>()
     for (const workspace of workspaces) {
         proportions.set(workspace.name, InitialABTestProportion)
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Create new type `proportion` and use it to store information about the proportions of traffic each workspace receives;
- rename `ABTestParameters` as `BetaParameters` and start using it only when talking about beta distributions' parameters;
- create an interface to store the bayesian revenue analysis' parameters;
- remove unused code.

#### What problem is this solving?
We've been saving the proportions of traffic in Router as if they were beta distributions' parameters: the proportion was saved as the first parameter, whereas the second parameter had no role at all. Now, the proportions are sent to the Router as what they are: sole numbers. This is going to avoid confusion and improve beginners' learning experience.

**These changes require changes in [Kube Router](https://github.com/vtex/kube-router)!**

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
