### PR TITLE
Remove pointless code in update.ts

### DIFF
--- a/node/abTest/commands/update.ts
+++ b/node/abTest/commands/update.ts
@@ -17,7 +17,7 @@ export async function UpdateStatusOnEvent(ctx: Context): Promise<void> {
       const testType = testData.testType
       const testApproach = testData.testApproach
       const workspacesData: WorkspaceData[] = (testApproach === 'frequentist' && testType === 'revenue') ? await GetGranularData(ctx) : await storedash.getWorkspacesData(beginning)
-      await UpdateProportions(ctx, beginning, hours, initialMasterProportion, workspacesData, testingWorkspaces, testingWorkspaces.Id() || 'noId', testType, testApproach)
+      await UpdateProportions(ctx, beginning, hours, initialMasterProportion, workspacesData, testingWorkspaces, testingWorkspaces.Id(), testType, testApproach)
     }
   } catch (err) {
     err.message = 'Error on test update: ' + err.message


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove a little piece of code that became pointless after [the change](https://github.com/vtex/ab-tester/pull/84/commits/a23788c9f81dd053349077336576839fb1aab0de) made in `node/typings/testingWorkspace.ts`.

#### What problem is this solving?
Avoid confusion. Also, it doesn't seem to make sense to set the id of every test that fall into that situation as `noId`: it wouldn't be nice to have two tests with the same id.