### PR TITLE
Improve performance  - winner calculation

### DIFF
--- a/node/abTest/analysis/compareWorkspaces/bayesianConversion.ts
+++ b/node/abTest/analysis/compareWorkspaces/bayesianConversion.ts
@@ -18,17 +18,24 @@ export function Evaluate(abTestBeginning: string, workspaceAData: WorkspaceCompl
     return EvaluationResponseBayesianConversion(abTestBeginning, workspaceAData, workspaceBData, winner, probabilityAbeatsB, lossA, lossB)
 }
 
-export function Winner(workspacesData: WorkspaceData[]): string {
-    if (!workspacesData || workspacesData.length === 0) return 'master'
+export function Winner(testResult: TestResult): string {
+    const results = testResult as BayesianEvaluationResultConversion[]
 
-    let winner = workspacesData[0]
-    for (const workspace of workspacesData) {
-        winner = chooseBetter(winner, workspace)
+    if (!results || results.length === 0) return 'master'
+
+    if (results[0].ExpectedLossChoosingA < results[0].ExpectedLossChoosingB) {
+        results.shift()
+        return Winner(results)
     }
-    return winner.Workspace
-}
 
-function chooseBetter(workspaceA: WorkspaceData, workspaceB: WorkspaceData): WorkspaceData {
-    const better = ChooseWinner(workspaceA, workspaceB)
-    return better === workspaceB.Workspace ? workspaceB : workspaceA
+    let winner = results[0].WorkspaceB
+    let loss = results[0].ExpectedLossChoosingB
+
+    for (let i = 1; i < results.length; i++) {
+        if (results[i].ExpectedLossChoosingB < loss) {
+            winner = results[i].WorkspaceB
+            loss = results[i].ExpectedLossChoosingB
+        }
+    }
+    return winner
 }

--- a/node/abTest/analysis/compareWorkspaces/frequentistConversion.ts
+++ b/node/abTest/analysis/compareWorkspaces/frequentistConversion.ts
@@ -19,21 +19,19 @@ export function Evaluate(abTestBeginning: string, workspaceA: WorkspaceCompleteD
     return EvaluationResponseFrequentistConversion(abTestBeginning, workspaceA, workspaceB, winner, pValue, upLiftChoosingA, upLiftChoosingB)
 }
 
-export function Winner(workspacesData: WorkspaceData[]): string {
-    if (!workspacesData || workspacesData.length === 0) return 'master'
-    
-    let winner = workspacesData[0]
-    for (const workspace of workspacesData) {
-        winner = chooseBetter(winner, workspace)
+export function Winner(testResult: TestResult): string {
+    const results = testResult as FrequentistEvaluationResultConversion[]
+
+    if (!results || results.length === 0) return 'master'
+
+    let winner = 'master'
+    let conversionRate = results[0].ConversionRateA
+
+    for (const workspace of results) {
+        if (workspace.ConversionRateB > conversionRate) {
+            winner = workspace.WorkspaceB
+            conversionRate = workspace.ConversionRateB
+        }
     }
-    return winner.Workspace
-}
-
-function chooseBetter(workspaceA: WorkspaceData, workspaceB: WorkspaceData): WorkspaceData {
-    const parametersA = ConversionToNormalDistribution(workspaceA)
-    const parametersB = ConversionToNormalDistribution(workspaceB)
-    const pValue = PValue(parametersA, parametersB)
-    const better = PickWinner(workspaceA.Workspace, workspaceB.Workspace, parametersA, parametersB, pValue)
-
-    return better === workspaceB.Workspace ? workspaceB : workspaceA
+    return winner
 }

--- a/node/abTest/analysis/compareWorkspaces/frequentistRevenue.ts
+++ b/node/abTest/analysis/compareWorkspaces/frequentistRevenue.ts
@@ -19,21 +19,19 @@ export function Evaluate(abTestBeginning: string, workspaceA: WorkspaceCompleteD
     return EvaluationResponseFrequentistRevenue(abTestBeginning, workspaceA, workspaceB, winner, pValue, upLiftChoosingA, upLiftChoosingB)
 }
 
-export function Winner(workspacesData: WorkspaceData[]): string {
-    if (!workspacesData || workspacesData.length === 0) return 'master'
-    
-    let winner = workspacesData[0]
-    for (const workspace of workspacesData) {
-        winner = chooseBetter(winner, workspace)
+export function Winner(testResult: TestResult): string {
+    const results = testResult as FrequentistEvaluationResultRevenue[]
+
+    if (!results || results.length === 0) return 'master'
+
+    let winner = 'master'
+    let averageRevenue = results[0].AverageRevenueA
+
+    for (const workspace of results) {
+        if (workspace.AverageRevenueB > averageRevenue) {
+            winner = workspace.WorkspaceB
+            averageRevenue = workspace.AverageRevenueB
+        }
     }
-    return winner.Workspace
-}
-
-function chooseBetter(workspaceA: WorkspaceData, workspaceB: WorkspaceData): WorkspaceData {
-    const parametersA = RevenueToNormalDistribution(workspaceA)
-    const parametersB = RevenueToNormalDistribution(workspaceB)
-    const pValue = PValue(parametersA, parametersB)
-    const better = PickWinner(workspaceA.Workspace, workspaceB.Workspace, parametersA, parametersB, pValue)
-
-    return better === workspaceB.Workspace ? workspaceB : workspaceA
+    return winner
 }

--- a/node/abTest/analysis/compareWorkspaces/index.ts
+++ b/node/abTest/analysis/compareWorkspaces/index.ts
@@ -7,8 +7,8 @@ export function Evaluate(testType: TestType, testApproach: TestApproach, abTestB
     return evaluateFunctions[testApproach][testType](abTestBeginning, workspaceA, workspaceB)
 }
 
-export function WinnerOverAll(testType: TestType, testApproach: TestApproach, workspacesData: WorkspaceData[]): WinnerOverAll {
-    return { Winner: winnerFunctions[testApproach][testType](workspacesData) }
+export function WinnerOverAll(testType: TestType, testApproach: TestApproach, testResult: TestResult): WinnerOverAll {
+    return { Winner: winnerFunctions[testApproach][testType](testResult) }
 }
 
 const evaluateFunctions = {

--- a/node/abTest/testWorkspaces.ts
+++ b/node/abTest/testWorkspaces.ts
@@ -28,13 +28,14 @@ export async function TestWorkspaces(ctx: Context, account: string, abTestBeginn
                 const workspacesCompleteData = await BuildCompleteData(account, abTestBeginning, workspacesData, storedash, abTestRouter)
                 const masterWorkspace = workspacesCompleteData.get(MasterWorkspaceName)
 
-                Results.push(WinnerOverAll(testType, approach, workspacesData))
-
                 for (const workspaceData of workspacesCompleteData) {
                     if (workspaceData[0] !== MasterWorkspaceName) {
                         Results.push(Evaluate(testType, approach, abTestBeginning, masterWorkspace!, workspaceData[1]))
                     }
                 }
+
+                Results.push(WinnerOverAll(testType, approach, Results))
+
             }
         } catch (err) {
             err.message = 'Error evaluating test results: ' + err.message


### PR DESCRIPTION
#### What is the purpose of this pull request?
Both of the frequentist analyses, when conclusive, opt for the workspace of bigger mean - whether the mean depicts the conversion rate or the average revenue. In the bayesian case, on the other hand, every time we compare a workspace with the master, we get the expected losses of both (workspaces) - one with respect to the other. 
This realization brings us the possibility of dramatically improving the performance of the process of choosing the best performing workspace over all. Instead of performing all the calculations again, we can use the results we get from the comparisons between the challengers and the master, in the bayesian case, or just look at the means, in the frequentist case.

#### What problem is this solving?
The main motivation for these changes relies on the perception of the fact that the calculations for the bayesian analysis of revenue are not as well-performing as one could wish. With these new methods, we don't have to perform all the calculations again - we just have to compare the means, in the frequentist case, and the results we already have, in the bayesian case.

#### Types of changes
- [x] Chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
