### PR TITLE
Fix probability function

### DIFF
--- a/node/typings/testingProportions.ts
+++ b/node/typings/testingProportions.ts
@@ -117,7 +117,7 @@ class TestingProportionsBayesianConversion extends GenericTestingProportions imp
         const size = betaParams.length
         for (let i = 0; i < size; i++) {
             const y = betaParams.shift()!
-            this.proportions.set(names.shift()!, ProbabilityYBeatsAll(y, betaParams))
+            this.proportions.set(names.shift()!, Math.round(10000*ProbabilityYBeatsAll(y, betaParams)))
             betaParams.push(y)
         }
     }

--- a/node/utils/mathTools/decisionRule/bayesianConversion.ts
+++ b/node/utils/mathTools/decisionRule/bayesianConversion.ts
@@ -81,8 +81,7 @@ export function ProbabilityYBeatsAll(Y: BetaParameters, X: Array<BetaParameters>
         curr *= Math.pow(-1, idxs.length)
         ret += curr
     }
-    ret *= 10000
-    return Math.round(ret)
+    return ret
 }
 
 export function LossFunctionChoosingVariantOne(Beta1: BetaParameters, Beta2: BetaParameters) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
In the updating process, when calculating the updated proportion of traffic that each workspace will receive, we multiply the probability of the workspace beating all of the others by `10000`, and then round the result. This is because the Router only accepts integer numbers as the proportions of traffic. 
This PR shifts this multiplication and rounding from the calculation of the probability to the updating function, for one of the four analyses (in the other three, things are already done correctly).

#### What problem is this solving?
It betters the organization to group the transformations of the probabilities into integers in one place. If at any time we need to change this part of the process, it will be a lot easier. Also, a function called `Probability{event}` should return the probability of `{event}` happening, not a random multiple of it. 

#### Types of changes
- [x] Chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
