### PR TITLE
Allow user to choose between MAB and regular A/B testing

### DIFF
--- a/node/abTest/commands/finish.ts
+++ b/node/abTest/commands/finish.ts
@@ -42,11 +42,11 @@ export async function FinishAbTestForWorkspace(ctx: Context): Promise<void> {
       const testingWorkspaces = new TestingWorkspaces({id: '', workspaces: currentWorkspaces.ToArray()})
 
       const testData = await storage.getTestData(ctx)
-      const [ testType, testApproach, initialMasterProportion, initialTime ] = [ testData.testType, testData.testApproach, testData.initialProportion, testData.initialStageTime ]
+      const [ testType, testApproach, initialMasterProportion, initialTime, isMAB ] = [ testData.testType, testData.testApproach, testData.initialProportion, testData.initialStageTime, testData.isMAB ]
       
       await InitializeWorkspaces(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray())
       await InitializeProportions(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray(), initialMasterProportion)
-      await storage.initializeABtest(testingWorkspaces.WorkspacesNames(), initialTime, initialMasterProportion, testType, testApproach, ctx)
+      await storage.initializeABtest(testingWorkspaces.WorkspacesNames(), initialTime, initialMasterProportion, testType, testApproach, isMAB, ctx)
 
       ctx.vtex.logger.info({ message: `A/B Test finished in ${account} for workspace ${workspaceName}`, account: `${account}`, workspace: `${workspaceName}`, method: 'TestFinished' })
     }

--- a/node/abTest/commands/initialize.ts
+++ b/node/abTest/commands/initialize.ts
@@ -56,7 +56,7 @@ async function InitializeAbTest(workspacesNames: string[], hoursOfInitialStage: 
         await InitializeWorkspaces(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray())
         await storage.initializeABtest(testingWorkspaces.WorkspacesNames(), hoursOfInitialStage, masterProportion, testType, approach, isMAB, ctx)
         
-        logger.info({message: `A/B Test initialized in ${account} for workspaces ${workspacesNames}`, account: `${account}`, workspaces: `${workspacesNames}`, proportion: `${masterProportion}`, type: `${testType}`, approach: `${approach}`, method: 'TestInitialized' })
+        logger.info({message: `A/B Test initialized in ${account} for workspaces ${workspacesNames}`, account: `${account}`, workspaces: `${workspacesNames}`, proportion: `${masterProportion}`, type: `${testType}`, approach: `${approach}`, isMAB: `${isMAB}`, method: 'TestInitialized' })
     } catch (err) {
         if (err.status === 404) {
             err.message = 'Workspace not found: ' + err.message

--- a/node/abTest/commands/initialize.ts
+++ b/node/abTest/commands/initialize.ts
@@ -6,17 +6,17 @@ import TestingWorkspaces from '../../typings/testingWorkspace'
 
 export function InitializeAbTestForWorkspace(ctx: Context): Promise<void> {
     const workspace = ctx.vtex.route.params.initializingWorkspace
-    return RunChecksAndInitialize(ctx, workspace, '1', '5000', 'conversion', 'bayesian')
+    return RunChecksAndInitialize(ctx, workspace, '1', '5000', 'conversion', 'bayesian', 'true')
 }
 
 export function InitializeAbTestForWorkspaceWithParameters(ctx: Context): Promise<void> {
     const { vtex: { route: { params: { hours, proportion, initializingWorkspace } } }} = ctx  
-    return RunChecksAndInitialize(ctx, initializingWorkspace, hours, proportion, 'conversion', 'bayesian')
+    return RunChecksAndInitialize(ctx, initializingWorkspace, hours, proportion, 'conversion', 'bayesian', 'true')
 }
 
 export async function InitializeAbTestWithBodyParameters(ctx: Context): Promise<void> {
-    const { InitializingWorkspaces, Hours, Proportion, Type, Approach } = await getRequestParams(ctx)
-    return RunChecksAndInitialize(ctx, InitializingWorkspaces, Hours, Proportion, Type, Approach)
+    const { InitializingWorkspaces, Hours, Proportion, Type, Approach, IsMAB } = await getRequestParams(ctx)
+    return RunChecksAndInitialize(ctx, InitializingWorkspaces, Hours, Proportion, Type, Approach, IsMAB)
 }
 
 async function RunChecksAndInitialize(ctx: Context, InitializingWorkspaces: UrlParameter, Hours: UrlParameter, Proportion: UrlParameter, Type: string, Approach: string): Promise<void> {

--- a/node/abTest/commands/initialize.ts
+++ b/node/abTest/commands/initialize.ts
@@ -1,6 +1,6 @@
 import { firstOrDefault } from '../../utils/firstOrDefault'
 import getRequestParams from '../../utils/Request/getRequestParams'
-import { checkTestType, checkTestApproach, checkIfNaN, CheckProportion, CheckInitializingWorkspaces as CheckWorkspaces } from '../../utils/Request/Checks'
+import { checkTestType, checkTestApproach, checkIsMAB, checkIfNaN, CheckProportion, CheckInitializingWorkspaces as CheckWorkspaces } from '../../utils/Request/Checks'
 import { InitializeProportions, InitializeWorkspaces } from '../initialize-Router'
 import TestingWorkspaces from '../../typings/testingWorkspace'
 
@@ -19,7 +19,7 @@ export async function InitializeAbTestWithBodyParameters(ctx: Context): Promise<
     return RunChecksAndInitialize(ctx, InitializingWorkspaces, Hours, Proportion, Type, Approach, IsMAB)
 }
 
-async function RunChecksAndInitialize(ctx: Context, InitializingWorkspaces: UrlParameter, Hours: UrlParameter, Proportion: UrlParameter, Type: string, Approach: string): Promise<void> {
+async function RunChecksAndInitialize(ctx: Context, InitializingWorkspaces: UrlParameter, Hours: UrlParameter, Proportion: UrlParameter, Type: string, Approach: string, IsMAB: string): Promise<void> {
     const [ workspacesString, hoursOfInitialStage, masterProportion ] = [ InitializingWorkspaces, Hours, Proportion ].map(firstOrDefault) 
 
     checkTestType(Type)
@@ -28,13 +28,16 @@ async function RunChecksAndInitialize(ctx: Context, InitializingWorkspaces: UrlP
     checkTestApproach(Approach)
     const approach = Approach as TestApproach
 
+    checkIsMAB(IsMAB)
+    const isMAB = IsMAB as unknown as boolean
+
     const workspacesNames = workspacesString.split(' ')
     await CheckWorkspaces(workspacesNames, ctx)
 
     checkIfNaN(hoursOfInitialStage, masterProportion)
     const [ numberHours, numberMasterProportion] = [ Number(hoursOfInitialStage), CheckProportion(Number(masterProportion))]
 
-    return InitializeAbTest(workspacesNames, numberHours, numberMasterProportion, ctx, testType, approach)
+    return InitializeAbTest(workspacesNames, numberHours, numberMasterProportion, ctx, testType, approach, isMAB)
 }
 
 async function InitializeAbTest(workspacesNames: string[], hoursOfInitialStage: number, masterProportion: number, ctx: Context, testType: TestType, approach: TestApproach): Promise<void> {

--- a/node/abTest/commands/initialize.ts
+++ b/node/abTest/commands/initialize.ts
@@ -40,7 +40,7 @@ async function RunChecksAndInitialize(ctx: Context, InitializingWorkspaces: UrlP
     return InitializeAbTest(workspacesNames, numberHours, numberMasterProportion, ctx, testType, approach, isMAB)
 }
 
-async function InitializeAbTest(workspacesNames: string[], hoursOfInitialStage: number, masterProportion: number, ctx: Context, testType: TestType, approach: TestApproach): Promise<void> {
+async function InitializeAbTest(workspacesNames: string[], hoursOfInitialStage: number, masterProportion: number, ctx: Context, testType: TestType, approach: TestApproach, isMAB: boolean): Promise<void> {
     const { vtex: { account, logger }, clients: { abTestRouter, storage } } = ctx
     try {
         const currentWorkspaces = await abTestRouter.getWorkspaces(account)   
@@ -54,7 +54,7 @@ async function InitializeAbTest(workspacesNames: string[], hoursOfInitialStage: 
         }
         await InitializeProportions(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray(), masterProportion)
         await InitializeWorkspaces(ctx, testingWorkspaces.Id(), testingWorkspaces.ToArray())
-        await storage.initializeABtest(testingWorkspaces.WorkspacesNames(), hoursOfInitialStage, masterProportion, testType, approach, ctx)
+        await storage.initializeABtest(testingWorkspaces.WorkspacesNames(), hoursOfInitialStage, masterProportion, testType, approach, isMAB, ctx)
         
         logger.info({message: `A/B Test initialized in ${account} for workspaces ${workspacesNames}`, account: `${account}`, workspaces: `${workspacesNames}`, proportion: `${masterProportion}`, type: `${testType}`, approach: `${approach}`, method: 'TestInitialized' })
     } catch (err) {

--- a/node/abTest/commands/update.ts
+++ b/node/abTest/commands/update.ts
@@ -3,14 +3,18 @@ import { UpdateProportions } from '../updateProportions'
 
 export async function UpdateStatusOnEvent(ctx: Context): Promise<void> {
   const { vtex: { account, logger }, clients: { abTestRouter, storedash, storage } } = ctx
+
   try {
     const testingWorkspaces = await abTestRouter.getWorkspaces(account)
+
     if (testingWorkspaces.Length() > 0) {
       const testData = await storage.getTestData(ctx)
+
       if (testData.isMAB || testData.isMAB === undefined) {
         let beginning = testData.dateOfBeginning
         let hours = testData.initialStageTime
         let initialMasterProportion = testData.initialProportion
+
         if (!(beginning && initialMasterProportion && hours !== undefined)) {
           beginning = new Date().toISOString().substr(0, 16)
           hours = 0
@@ -19,6 +23,7 @@ export async function UpdateStatusOnEvent(ctx: Context): Promise<void> {
         const testType = testData.testType
         const testApproach = testData.testApproach
         const workspacesData: WorkspaceData[] = (testApproach === 'frequentist' && testType === 'revenue') ? await GetGranularData(ctx) : await storedash.getWorkspacesData(beginning)
+
         await UpdateProportions(ctx, beginning, hours, initialMasterProportion, workspacesData, testingWorkspaces, testingWorkspaces.Id(), testType, testApproach)
       }
     }

--- a/node/abTest/commands/update.ts
+++ b/node/abTest/commands/update.ts
@@ -7,18 +7,20 @@ export async function UpdateStatusOnEvent(ctx: Context): Promise<void> {
     const testingWorkspaces = await abTestRouter.getWorkspaces(account)
     if (testingWorkspaces.Length() > 0) {
       const testData = await storage.getTestData(ctx)
-      let beginning = testData.dateOfBeginning
-      let hours = testData.initialStageTime
-      let initialMasterProportion = testData.initialProportion
-      if (!(beginning && initialMasterProportion && hours !== undefined)) {
-        beginning = new Date().toISOString().substr(0, 16)
-        hours = 0
-        initialMasterProportion = 5000
+      if (testData.isMAB || testData.isMAB === undefined) {
+        let beginning = testData.dateOfBeginning
+        let hours = testData.initialStageTime
+        let initialMasterProportion = testData.initialProportion
+        if (!(beginning && initialMasterProportion && hours !== undefined)) {
+          beginning = new Date().toISOString().substr(0, 16)
+          hours = 0
+          initialMasterProportion = 5000
+        }
+        const testType = testData.testType
+        const testApproach = testData.testApproach
+        const workspacesData: WorkspaceData[] = (testApproach === 'frequentist' && testType === 'revenue') ? await GetGranularData(ctx) : await storedash.getWorkspacesData(beginning)
+        await UpdateProportions(ctx, beginning, hours, initialMasterProportion, workspacesData, testingWorkspaces, testingWorkspaces.Id(), testType, testApproach)
       }
-      const testType = testData.testType
-      const testApproach = testData.testApproach
-      const workspacesData: WorkspaceData[] = (testApproach === 'frequentist' && testType === 'revenue') ? await GetGranularData(ctx) : await storedash.getWorkspacesData(beginning)
-      await UpdateProportions(ctx, beginning, hours, initialMasterProportion, workspacesData, testingWorkspaces, testingWorkspaces.Id(), testType, testApproach)
     }
   } catch (err) {
     err.message = 'Error on test update: ' + err.message

--- a/node/abTest/commands/update.ts
+++ b/node/abTest/commands/update.ts
@@ -22,9 +22,10 @@ export async function UpdateStatusOnEvent(ctx: Context): Promise<void> {
         }
         const testType = testData.testType
         const testApproach = testData.testApproach
+        const isMAB = testData.isMAB
         const workspacesData: WorkspaceData[] = (testApproach === 'frequentist' && testType === 'revenue') ? await GetGranularData(ctx) : await storedash.getWorkspacesData(beginning)
 
-        await UpdateProportions(ctx, beginning, hours, initialMasterProportion, workspacesData, testingWorkspaces, testingWorkspaces.Id(), testType, testApproach)
+        await UpdateProportions(ctx, beginning, hours, initialMasterProportion, workspacesData, testingWorkspaces, testingWorkspaces.Id(), testType, testApproach, isMAB)
       }
     }
   } catch (err) {

--- a/node/abTest/updateProportions.ts
+++ b/node/abTest/updateProportions.ts
@@ -11,7 +11,7 @@ import { InitializeProportions } from './initialize-Router'
 const MasterWorkspaceName = 'master'
 
 export async function UpdateProportions(ctx: Context, aBTestBeginning: string, hoursOfInitialStage: number, masterProportion: number,
-    workspacesData: WorkspaceData[], testingWorkspaces: TestingWorkspaces, testId: string, testType: TestType, approach: TestApproach): Promise<void> {
+    workspacesData: WorkspaceData[], testingWorkspaces: TestingWorkspaces, testId: string, testType: TestType, approach: TestApproach, isMAB: boolean): Promise<void> {
     try { 
         const { clients: { abTestRouter, storedash, storage } } = ctx
         const testingProportions = createTestingProportions(testType, approach, testingWorkspaces.ToArray())
@@ -41,7 +41,7 @@ export async function UpdateProportions(ctx: Context, aBTestBeginning: string, h
             return
         }
         await InitializeProportions(ctx, testId, testingWorkspaces.ToArray(), masterProportion)
-        await storage.initializeABtest(testingWorkspaces.WorkspacesNames(), hoursOfInitialStage, masterProportion, testType, approach, ctx)
+        await storage.initializeABtest(testingWorkspaces.WorkspacesNames(), hoursOfInitialStage, masterProportion, testType, approach, isMAB, ctx)
 
     } catch (err) {
         err.message = 'Error updating proportions: ' + err.message

--- a/node/clients/vbase.ts
+++ b/node/clients/vbase.ts
@@ -53,7 +53,7 @@ export default class VBase extends BaseClient {
     }
   }
 
-  public initializeABtest = async (testingWorkspaces: string[], initialTime: number, masterProportion: number, testType: TestType, approach: TestApproach, ctx: Context) => {
+  public initializeABtest = async (testingWorkspaces: string[], initialTime: number, masterProportion: number, testType: TestType, approach: TestApproach, isMAB: boolean, ctx: Context) => {
     const beginning = new Date().toISOString().substr(0, 16)
     try {
       const initialCache = InitialWorkspaceDataCache(new Date(), testingWorkspaces)
@@ -68,7 +68,8 @@ export default class VBase extends BaseClient {
         initialProportion: masterProportion,
         initialStageTime: initialTime,
         testType: testType,
-        testApproach: approach
+        testApproach: approach,
+        isMAB: isMAB
       } as VBaseABTestData, testFileName, ctx)
     } catch (err) {
       err.message = 'Error setting initial test data on VBase: ' + err.message

--- a/node/clients/vbase.ts
+++ b/node/clients/vbase.ts
@@ -176,6 +176,7 @@ declare global {
     initialProportion: number
     testType: TestType
     testApproach: TestApproach
+    isMAB: boolean
   }
 
   interface WorkspaceDataCache {

--- a/node/utils/Request/Checks.ts
+++ b/node/utils/Request/Checks.ts
@@ -31,6 +31,15 @@ export const checkTestApproach = (Approach: string) => {
     }
 }
 
+export const checkIsMAB = (IsMAB: string) => {
+    if (IsMAB !== 'true' && IsMAB !== 'false') {
+        const err = new Error(`Error setting IsMAB option: please make sure to spell it correctly (either 'true' or 'false')`) as any
+        err.status = 400
+        throw err
+    }
+}
+
+
 export const checkIfNaN = (hours: string, proportion: string) => {
     if (Number.isNaN(Number(hours))) {
         const err = new Error(`Error reading time parameter: make sure to insert a number`) as any

--- a/node/utils/Request/Checks.ts
+++ b/node/utils/Request/Checks.ts
@@ -2,7 +2,7 @@ import { concatErrorMessages } from '../../utils/errorHandling'
 import { WorkspaceMetadata } from '@vtex/api'
 import TestingWorkspaces from '../../typings/testingWorkspace'
 
-const expectedFields = ['InitializingWorkspaces', 'Hours', 'Proportion', 'Type', 'Approach']
+const expectedFields = ['InitializingWorkspaces', 'Hours', 'Proportion', 'Type', 'Approach', 'IsMAB']
 
 export const checkForExpectedFields = (object: object) => {
     for (let idx = 0; idx < expectedFields.length; idx++) {

--- a/node/utils/Request/getRequestParams.ts
+++ b/node/utils/Request/getRequestParams.ts
@@ -4,7 +4,7 @@ import { checkForExpectedFields } from './Checks'
 export default async (ctx: Context) => {   
     const bodyContent = await readBody(ctx)
     checkForExpectedFields(bodyContent)
-    const { InitializingWorkspaces, Hours, Proportion, Type, Approach } = bodyContent  
+    const { InitializingWorkspaces, Hours, Proportion, Type, Approach, IsMAB } = bodyContent  
 
-    return { InitializingWorkspaces, Hours, Proportion, Type, Approach }
+    return { InitializingWorkspaces, Hours, Proportion, Type, Approach, IsMAB }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make it possible for the user to choose between MAB and regular A/B testing. Also, of course, ignore updating event when performing a regular test.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
