### PR TITLE
fix has0or1Probability functions

### DIFF
--- a/node/utils/mathTools/forBetaDistribution/statistics/densityEstimations.ts
+++ b/node/utils/mathTools/forBetaDistribution/statistics/densityEstimations.ts
@@ -18,13 +18,14 @@ const error = 1e-4      // mind the fact that this has not the same role as the 
 export function has0or1Probability(X: BetaParameters, Others: BetaParameters[], boundX: number, boundsOthers: number[], r: number[]): [boolean, number] {
     const lowerBoundX = calculateLowerBound(X.a, X.b)
 
+    let has = true
     for (const i in Others) {
         const lowerBound = calculateLowerBound(Others[i].a, Others[i].b)
 
         if (r[i]*boundX < lowerBound) return [true, 0]
-        if (r[i] * lowerBoundX < boundsOthers[i]) return [false, NaN]
+        if (r[i] * lowerBoundX < boundsOthers[i]) has = false
     }
-    return [true, 1]
+    return [has, 1]
 }
 
 // Returns l in [0,1) such that beta(a,b)(x) > 1/e^10 => x > l.

--- a/node/utils/mathTools/forNormalDistribution/densityEstimation.ts
+++ b/node/utils/mathTools/forNormalDistribution/densityEstimation.ts
@@ -16,11 +16,12 @@ const error = 1e-5
 // On the other hand, if none of the points in the significant interval satisfy the inequality,
 // the integration amounts to approximately - with extremely small error - zero.
 export function has0or1Probability(boundsX: Bounds, boundsOthers: Bounds[]): [boolean, number] {
+    let has = true
     for (const i in boundsOthers) {
         if (boundsX.u < boundsOthers[i].l) return [true, 0]
-        if (boundsX.l < boundsOthers[i].u) return [false, NaN]
+        if (boundsX.l < boundsOthers[i].u) has = false
     }
-    return [true, 1]
+    return [has, 1]
 }
 
 // Returns l and u such that PDF(x) > error => l < x < u.


### PR DESCRIPTION
#### What problem is this solving?
It is enough that `X`'s upper bound be smaller than one of the `others`' lower bounds for us to conclude that the probability under calculation is null.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
