### PR TITLE
Stop requiring Hour field when not MAB

### DIFF
--- a/node/utils/Request/Checks.ts
+++ b/node/utils/Request/Checks.ts
@@ -5,8 +5,7 @@ import TestingWorkspaces from '../../typings/testingWorkspace'
 const expectedFields = ['InitializingWorkspaces', 'Hours', 'Proportion', 'Type', 'Approach', 'IsMAB']
 
 export const checkForExpectedFields = (object: object) => {
-    for (let idx = 0; idx < expectedFields.length; idx++) {
-        const field = expectedFields[idx]
+    for (const field of expectedFields) {
         if (!(field in object)) {
             const err = new Error(`Error getting request's parameters: make sure to set the ${field} field`) as any
             err.status = 400

--- a/node/utils/Request/Checks.ts
+++ b/node/utils/Request/Checks.ts
@@ -2,15 +2,20 @@ import { concatErrorMessages } from '../../utils/errorHandling'
 import { WorkspaceMetadata } from '@vtex/api'
 import TestingWorkspaces from '../../typings/testingWorkspace'
 
-const expectedFields = ['InitializingWorkspaces', 'Hours', 'Proportion', 'Type', 'Approach', 'IsMAB']
+const expectedFields = ['InitializingWorkspaces', 'Proportion', 'Type', 'Approach', 'IsMAB']
 
-export const checkForExpectedFields = (object: object) => {
+export const checkForExpectedFields = (object: any) => {
     for (const field of expectedFields) {
         if (!(field in object)) {
             const err = new Error(`Error getting request's parameters: make sure to set the ${field} field`) as any
             err.status = 400
             throw err
         }
+    }
+    if (object['IsMAB'] === 'true') if (!("Hours" in object)) {
+        const err = new Error(`Error getting request's parameters: make sure to set the Hours field`) as any
+        err.status = 400
+        throw err
     }
 }
 

--- a/node/utils/Request/getRequestParams.ts
+++ b/node/utils/Request/getRequestParams.ts
@@ -4,7 +4,8 @@ import { checkForExpectedFields } from './Checks'
 export default async (ctx: Context) => {   
     const bodyContent = await readBody(ctx)
     checkForExpectedFields(bodyContent)
-    const { InitializingWorkspaces, Hours, Proportion, Type, Approach, IsMAB } = bodyContent  
+    const { InitializingWorkspaces, Proportion, Type, Approach, IsMAB } = bodyContent
+    const Hours = bodyContent["Hours"] ? bodyContent["Hours"] : "1" 
 
     return { InitializingWorkspaces, Hours, Proportion, Type, Approach, IsMAB }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Stop requiring that the user sets a time for the initial proportion if the test is not MAB. 

#### What problem is this solving?
If the test is not MAB, the proportion never changes, so it doesn't make sense to require that the user sets "the amount of time during which the proportion won't change".

#### How should this be manually tested?
Try to initialize a test setting `"IsMAB": "true"` and then try it again, this time with `"IsMAB": "false"`. In each situation, check whether the app responds as expected. If the router throws any error, it might be because of [#98](https://github.com/vtex/ab-tester/pull/98).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
